### PR TITLE
fix(scenario-convert): improve export of MOSAIC scenarios

### DIFF
--- a/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/config/model/CNetworkProperties.java
+++ b/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/config/model/CNetworkProperties.java
@@ -66,7 +66,7 @@ public class CNetworkProperties {
          * Current capacity.
          */
         @JsonAdapter(DataFieldAdapter.Bandwidth.class)
-        public long capacity;
+        public Long capacity;
         /**
          * The maximal Capacity (when no transmission is ongoing).
          */
@@ -93,7 +93,7 @@ public class CNetworkProperties {
          * Shared capacity between unicast and multicast.
          */
         @JsonAdapter(DataFieldAdapter.Bandwidth.class)
-        public long capacity;
+        public Long capacity;
         /**
          * The maximal Capacity (when no transmission is ongoing).
          */

--- a/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/config/util/ConfigurationReader.java
+++ b/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/config/util/ConfigurationReader.java
@@ -74,6 +74,22 @@ public class ConfigurationReader {
         networkConfig.globalNetwork.downlink.maxCapacity = networkConfig.globalNetwork.downlink.capacity;
         networkConfig.globalNetwork.uplink.maxCapacity = networkConfig.globalNetwork.uplink.capacity;
 
+        // server capacity isn't limited by the network configuration, but handled within the cell module configuration
+        networkConfig.servers.forEach((server) -> {
+            if (ObjectUtils.defaultIfNull(server.downlink.capacity, 0L) != 0 ||
+                    ObjectUtils.defaultIfNull(server.uplink.capacity, 0L) != 0) {
+                log.warn("It seems like you've tried to set a capacity value for a server. This should be done when enabling the "
+                        + "CellModule in you application. Your set values will be dismissed");
+            }
+            if (server.downlink.multicast != null) {
+                log.warn("It seems like you've tried to set the downlink multicast for a server."
+                        + "Servers can't be addressed with multicasts. Your set values will be dismissed");
+            }
+            server.downlink.maxCapacity = server.downlink.capacity = Long.MAX_VALUE;
+            server.uplink.maxCapacity = server.uplink.capacity = Long.MAX_VALUE;
+            server.downlink.multicast = null;
+        });
+
         return networkConfig;
     }
 

--- a/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/config/util/ConfigurationReader.java
+++ b/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/config/util/ConfigurationReader.java
@@ -30,6 +30,7 @@ import org.eclipse.mosaic.rti.api.InternalFederateException;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,21 +74,6 @@ public class ConfigurationReader {
         networkConfig.globalNetwork.downlink.maxCapacity = networkConfig.globalNetwork.downlink.capacity;
         networkConfig.globalNetwork.uplink.maxCapacity = networkConfig.globalNetwork.uplink.capacity;
 
-        // server capacity isn't limited by the network configuration, but handled within the cell module configuration
-        networkConfig.servers.forEach((server) -> {
-            if (server.downlink.capacity != 0 || server.uplink.capacity != 0) {
-                log.warn("It seems like you've tried to set a capacity value for a server. This should be done when enabling the "
-                        + "CellModule in you application. Your set values will be dismissed");
-            }
-            if (server.downlink.multicast != null) {
-                log.warn("It seems like you've tried to set the downlink multicast for a server."
-                        + "Servers can't be addressed with multicasts. Your set values will be dismissed");
-            }
-            server.downlink.maxCapacity = server.downlink.capacity = Long.MAX_VALUE;
-            server.uplink.maxCapacity = server.uplink.capacity = Long.MAX_VALUE;
-            server.downlink.multicast = null;
-        });
-
         return networkConfig;
     }
 
@@ -101,6 +87,8 @@ public class ConfigurationReader {
     public static CRegion importRegionConfig(String regionConfigPath) throws InternalFederateException {
         CRegion regionConfig = readConfigFile(regionConfigPath, ConfigBuilderFactory.getConfigBuilder(), CRegion.class);
         regionConfig.regions.forEach((region) -> {
+            region.downlink.capacity = ObjectUtils.defaultIfNull(region.downlink.capacity, 0L);
+            region.uplink.capacity = ObjectUtils.defaultIfNull(region.uplink.capacity, 0L);
             /*
              * Here the maximum capacity is set for the region.
              * The maximum capacity is needed to compute what

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/config/CNetworkImportTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/config/CNetworkImportTest.java
@@ -124,9 +124,9 @@ public class CNetworkImportTest {
 
         assertEquals(0.1, server.downlink.unicast.transmission.lossProbability, EPSILON);
 
-        assertEquals(Long.MAX_VALUE, server.uplink.capacity);
+        assertEquals(Long.MAX_VALUE, server.uplink.capacity.longValue());
         assertEquals(Long.MAX_VALUE, server.uplink.maxCapacity);
-        assertEquals(Long.MAX_VALUE, server.downlink.capacity);
+        assertEquals(Long.MAX_VALUE, server.downlink.capacity.longValue());
         assertEquals(Long.MAX_VALUE, server.downlink.maxCapacity);
     }
 }

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/config/ConfigurationTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/config/ConfigurationTest.java
@@ -119,8 +119,8 @@ public class ConfigurationTest {
 
         assertEquals(0.5, region.downlink.multicast.transmission.lossProbability, EPSILON);
 
-        assertEquals(2000, region.uplink.capacity);
-        assertEquals(42000, region.downlink.capacity);
+        assertEquals(2000, region.uplink.capacity.longValue());
+        assertEquals(42000, region.downlink.capacity.longValue());
     }
 
     @Test

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleStreamingTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleStreamingTest.java
@@ -55,6 +55,7 @@ import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
 import org.eclipse.mosaic.lib.objects.v2x.V2xMessage;
 import org.eclipse.mosaic.lib.objects.v2x.V2xReceiverInformation;
 import org.eclipse.mosaic.lib.util.scheduling.Event;
+import org.eclipse.mosaic.rti.DATA;
 import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.Interaction;
@@ -200,7 +201,7 @@ public class DownstreamModuleStreamingTest {
             assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode(receivers[i]).getAvailableDownlinkBitrate());
         }
 
-        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -237,15 +238,15 @@ public class DownstreamModuleStreamingTest {
             testRtiV2xMessages(i, receivers[i], endTime, sampleV2XMessage.getId());
             assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode(receivers[i]).getAvailableDownlinkBitrate());
         }
-        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
     public void testProcessMessage_regularMessageMulticast_NodeLimitedRegionLimited() throws Exception {
         // SETUP
         // UDP
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 200;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 200;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 200 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 200 * DATA.BIT;
 
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
@@ -270,7 +271,7 @@ public class DownstreamModuleStreamingTest {
         // ASSERT
         assertEquals(0, rtiInteractionsSent.size());
         assertEquals(0, cellModuleMessages.size());
-        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -281,8 +282,8 @@ public class DownstreamModuleStreamingTest {
         GeoPoint moritzplatzKreuzbergGeo = GeoPoint.lonLat(13.423233032226562, 52.50007194840628);
         CartesianPoint moritzplatzKreuzbergCartesian = moritzplatzKreuzbergGeo.toCartesian();
 
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 2000;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 2000;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 2000 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 2000 * DATA.BIT;
 
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
@@ -333,7 +334,7 @@ public class DownstreamModuleStreamingTest {
                 sampleV2XMessage
         );
 
-        assertEquals(EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
 
         for (int i = 1; i < receivers.length; i++) {
             assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode(receivers[i]).getAvailableDownlinkBitrate());
@@ -367,7 +368,7 @@ public class DownstreamModuleStreamingTest {
         assertEquals(0, cellModuleMessages.size());
 
         assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -385,8 +386,8 @@ public class DownstreamModuleStreamingTest {
 
         CellConfiguration cellConfiguration = new CellConfiguration(receiverName, true, 400L, 400L);
         SimulationData.INSTANCE.setCellConfigurationOfNode(receiverName, cellConfiguration);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 600;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 600;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 600 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 600 * DATA.BIT;
 
         // RUN
         downstreamModule.processEvent(event);
@@ -396,7 +397,7 @@ public class DownstreamModuleStreamingTest {
         assertEquals(0, cellModuleMessages.size());
 
         assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableDownlinkBitrate());
-        assertEquals(600, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(600, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -414,8 +415,8 @@ public class DownstreamModuleStreamingTest {
 
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 400L, 400L);
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_0", cellConfiguration);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 200;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 200;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 200 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 200 * DATA.BIT;
 
         // RUN
         downstreamModule.processEvent(event);
@@ -425,7 +426,7 @@ public class DownstreamModuleStreamingTest {
         assertEquals(0, cellModuleMessages.size());
 
         assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableDownlinkBitrate());
-        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -456,7 +457,7 @@ public class DownstreamModuleStreamingTest {
 
         assertEquals(Long.MAX_VALUE - EVENT_BANDWIDTH, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName)
                 .getAvailableDownlinkBitrate());
-        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
 
         // FREE
         // SETUP
@@ -468,7 +469,7 @@ public class DownstreamModuleStreamingTest {
 
         // ASSERT
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -484,8 +485,8 @@ public class DownstreamModuleStreamingTest {
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
 
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 200;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 200;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 200 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 200 * DATA.BIT;
 
         // RUN
         downstreamModule.processEvent(event);
@@ -494,7 +495,7 @@ public class DownstreamModuleStreamingTest {
         assertEquals(0, rtiInteractionsSent.size());
 
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -533,7 +534,7 @@ public class DownstreamModuleStreamingTest {
                 Long.MAX_VALUE - EVENT_BANDWIDTH,
                 SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate()
         );
-        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -569,7 +570,7 @@ public class DownstreamModuleStreamingTest {
                 Long.MAX_VALUE - EVENT_BANDWIDTH,
                 SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate()
         );
-        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 - EVENT_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -601,7 +602,7 @@ public class DownstreamModuleStreamingTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage, false);
 
         assertEquals(0, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -620,8 +621,8 @@ public class DownstreamModuleStreamingTest {
 
         CellConfiguration cellConfiguration = SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName);
         cellConfiguration.consumeDownlink(Long.MAX_VALUE);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 2000;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 2000;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 2000 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 2000 * DATA.BIT;
 
         // RUN
         downstreamModule.processEvent(event);
@@ -635,7 +636,7 @@ public class DownstreamModuleStreamingTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage, false);
 
         assertEquals(0, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(2000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(2000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -652,7 +653,7 @@ public class DownstreamModuleStreamingTest {
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
 
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 0;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 0L;
 
         // RUN
         downstreamModule.processEvent(event);
@@ -666,7 +667,7 @@ public class DownstreamModuleStreamingTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage, false);
 
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -683,7 +684,7 @@ public class DownstreamModuleStreamingTest {
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
 
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 0;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 0L;
         CellConfiguration cellConfiguration = SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName);
         cellConfiguration.consumeDownlink(Long.MAX_VALUE);
 
@@ -700,7 +701,7 @@ public class DownstreamModuleStreamingTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage, false);
 
         assertEquals(0, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -731,7 +732,7 @@ public class DownstreamModuleStreamingTest {
         List<NegativeAckReason> nackReasons = Arrays.asList(NegativeAckReason.NODE_DEACTIVATED);
         testRtiAckMessages(0, nackReasons, sampleV2XMessage, false);
 
-        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
     }
 
@@ -782,7 +783,7 @@ public class DownstreamModuleStreamingTest {
         List<NegativeAckReason> nackReasons = Collections.singletonList(NegativeAckReason.NODE_DEACTIVATED);
         testRtiAckMessages(0, nackReasons, sampleV2XMessage, false);
 
-        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableDownlinkBitrate());
     }
 
@@ -813,7 +814,7 @@ public class DownstreamModuleStreamingTest {
         CellConfiguration cellConfiguration = new CellConfiguration(receiverName, true, 400L, 400L);
         NodeCapacityUtility.consumeCapacityDown(cellConfiguration, 200);
         SimulationData.INSTANCE.setCellConfigurationOfNode(receiverName, cellConfiguration);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 42000 - 200;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = (42000 - 200) * DATA.BIT;
         // long tmp = ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity;
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
@@ -835,7 +836,7 @@ public class DownstreamModuleStreamingTest {
 
         // ASSERT
         assertEquals(400, cellConfiguration.getAvailableDownlinkBitrate());
-        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     private void testRtiAckMessages(int index,

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleTest.java
@@ -195,7 +195,7 @@ public class DownstreamModuleTest {
             );
         }
 
-        assertEquals((42000 - 8960) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals((42000 - 8960) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -232,7 +232,7 @@ public class DownstreamModuleTest {
             assertEquals(10000 * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode(receivers[i]).getAvailableDownlinkBitrate());
         }
 
-        assertEquals((42000 - 8960) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals((42000 - 8960) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -268,7 +268,7 @@ public class DownstreamModuleTest {
         //640 bps of capacity remain, since only 50% of the full capacity is usable for the Multicast
         long endTime = 10 * TIME.SECOND + 800 * TIME.MILLI_SECOND;
         checkNotifyOnFinishMessage(0, GLOBAL_NETWORK_ID, 560 * DATA.BIT, 10 * TIME.SECOND, endTime);
-        assertEquals(560 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(560 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
 
         for (int i = 0; i < receivers.length; i++) {
             testRtiV2xMessages(i, receivers[i], endTime, sampleV2XMessage.getId());
@@ -333,7 +333,7 @@ public class DownstreamModuleTest {
                 sampleV2XMessage
         );
 
-        assertEquals(560 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(560 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
 
         for (int i = 1; i < receivers.length; i++) {
             assertEquals(2240 * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode(receivers[i]).getAvailableDownlinkBitrate());
@@ -370,7 +370,7 @@ public class DownstreamModuleTest {
         testRtiV2xMessages(0, receiverName, endTime, sampleV2XMessage.getId());
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals((42000 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals((42000 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -402,7 +402,7 @@ public class DownstreamModuleTest {
         testRtiV2xMessages(0, receiverName, endTime, sampleV2XMessage.getId());
 
         assertEquals(0, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableDownlinkBitrate());
-        assertEquals((3360 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals((3360 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -434,7 +434,7 @@ public class DownstreamModuleTest {
         testRtiV2xMessages(0, receiverName, endTime, sampleV2XMessage.getId());
 
         assertEquals((2240 - 1120) * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableDownlinkBitrate());
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -466,7 +466,7 @@ public class DownstreamModuleTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage);
 
         assertEquals(2240 * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(3360 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(3360 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -500,7 +500,7 @@ public class DownstreamModuleTest {
         );
         assertEquals(
                 (42000 - expectedBandwidthInBps) * DATA.BIT,
-                ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity)
+                ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue())
         ;
 
         // FREE
@@ -513,7 +513,7 @@ public class DownstreamModuleTest {
 
         // ASSERT
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
 
 
     }
@@ -552,7 +552,7 @@ public class DownstreamModuleTest {
                 (Long.MAX_VALUE - expectedBandwidthInBps) * DATA.BIT,
                 SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate()
         );
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -593,7 +593,7 @@ public class DownstreamModuleTest {
                 (Long.MAX_VALUE - expectedBandwidth) * DATA.BIT,
                 SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate()
         );
-        assertEquals((42000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals((42000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -626,7 +626,7 @@ public class DownstreamModuleTest {
                 (Long.MAX_VALUE - expectedBandwidth) * DATA.BIT,
                 SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate()
         );
-        assertEquals((42000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals((42000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -658,7 +658,7 @@ public class DownstreamModuleTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage);
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -691,7 +691,7 @@ public class DownstreamModuleTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage);
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(1140 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(1140 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -721,7 +721,7 @@ public class DownstreamModuleTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage);
 
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -755,7 +755,7 @@ public class DownstreamModuleTest {
         testRtiAckMessages(0, nackReasons, sampleV2XMessage);
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     @Test
@@ -785,7 +785,7 @@ public class DownstreamModuleTest {
         List<NegativeAckReason> nackReasons = Arrays.asList(NegativeAckReason.NODE_DEACTIVATED);
         testRtiAckMessages(0, nackReasons, sampleV2XMessage);
 
-        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode(receiverName).getAvailableDownlinkBitrate());
     }
 
@@ -831,7 +831,7 @@ public class DownstreamModuleTest {
         List<NegativeAckReason> nackReasons = Collections.singletonList(NegativeAckReason.NODE_DEACTIVATED);
         testRtiAckMessages(0, nackReasons, sampleV2XMessage);
 
-        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableDownlinkBitrate());
     }
 
@@ -875,7 +875,7 @@ public class DownstreamModuleTest {
 
         // ASSERT
         assertEquals(400 * DATA.BIT, cellConfiguration.getAvailableDownlinkBitrate());
-        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity);
+        assertEquals(42000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity.longValue());
     }
 
     private void testRtiAckMessages(int index, List<NegativeAckReason> negativeAckReasons, SampleV2xMessage sampleV2XMessage) {

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleStreamingTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleStreamingTest.java
@@ -53,6 +53,7 @@ import org.eclipse.mosaic.lib.objects.communication.CellConfiguration;
 import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
 import org.eclipse.mosaic.lib.objects.v2x.MessageStreamRouting;
 import org.eclipse.mosaic.lib.util.scheduling.Event;
+import org.eclipse.mosaic.rti.DATA;
 import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.Interaction;
@@ -128,9 +129,9 @@ public class UpstreamModuleStreamingTest {
     // event duration is given in ns
     private final static long EVENT_DURATION = 8 * TIME.SECOND;
     // message size is given in bytes
-    private final static int MESSAGE_SIZE = 1000;
+    private final static long MESSAGE_SIZE = 1000;
     // expected bandwidth is given in bits per second
-    private final static int EXPECTED_BANDWIDTH = 1000;
+    private final static long EXPECTED_BANDWIDTH = 1000 * DATA.BIT;
 
     @Before
     public void setup() throws IllegalValueException, InternalFederateException {
@@ -184,7 +185,7 @@ public class UpstreamModuleStreamingTest {
         assertEquals(0, cellModuleMessages.size());
 
         assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -198,8 +199,8 @@ public class UpstreamModuleStreamingTest {
 
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 400L, 400L);
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_0", cellConfiguration);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 600;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.maxCapacity = 600;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 600 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.maxCapacity = 600 * DATA.BIT;
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         Event event = new Event(10 * TIME.SECOND, upstreamModule, sampleV2XMessage);
@@ -211,7 +212,7 @@ public class UpstreamModuleStreamingTest {
         assertEquals(0, cellModuleMessages.size());
 
         assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(600, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(600, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -225,8 +226,8 @@ public class UpstreamModuleStreamingTest {
 
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 400L, 400L);
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_0", cellConfiguration);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 200;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.maxCapacity = 200;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 200 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.maxCapacity = 200 * DATA.BIT;
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         Event event = new Event(10 * TIME.SECOND, upstreamModule, sampleV2XMessage);
@@ -238,7 +239,7 @@ public class UpstreamModuleStreamingTest {
         assertEquals(0, cellModuleMessages.size());
 
         assertEquals(400, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -261,7 +262,7 @@ public class UpstreamModuleStreamingTest {
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 400L, 400L);
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_0", cellConfiguration);
         // because the default maxCapacity of the region is 21000 setting the capacity to 600 bps results in a blocking of the region
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 600;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 600 * DATA.BIT;
 
         // RUN
         upstreamModule.processEvent(event);
@@ -279,7 +280,7 @@ public class UpstreamModuleStreamingTest {
         assertEquals(0, rtiInteractionsSent.size());
 
         assertEquals(400 - smallerStreamSize, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(600 - smallerStreamSize, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(600 - smallerStreamSize, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -311,7 +312,7 @@ public class UpstreamModuleStreamingTest {
 
         assertEquals(Long.MAX_VALUE - EXPECTED_BANDWIDTH, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0")
                 .getAvailableUplinkBitrate());
-        assertEquals(21000 - EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 - EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
 
         // FREE
         // SETUP
@@ -322,7 +323,7 @@ public class UpstreamModuleStreamingTest {
 
         // ASSERT
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -337,8 +338,8 @@ public class UpstreamModuleStreamingTest {
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         Event event = new Event(10 * TIME.SECOND, upstreamModule, sampleV2XMessage);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 200;
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.maxCapacity = 200;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 200 * DATA.BIT;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.maxCapacity = 200 * DATA.BIT;
 
         // RUN
         upstreamModule.processEvent(event);
@@ -350,7 +351,7 @@ public class UpstreamModuleStreamingTest {
         assertEquals(0, rtiInteractionsSent.size());
 
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(200, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
 
     }
 
@@ -386,7 +387,7 @@ public class UpstreamModuleStreamingTest {
 
         assertEquals(Long.MAX_VALUE - EXPECTED_BANDWIDTH, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0")
                 .getAvailableUplinkBitrate());
-        assertEquals(21000 - EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 - EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -420,7 +421,7 @@ public class UpstreamModuleStreamingTest {
 
         assertEquals(Long.MAX_VALUE - EXPECTED_BANDWIDTH, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0")
                 .getAvailableUplinkBitrate());
-        assertEquals(21000 - EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 - EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -451,7 +452,7 @@ public class UpstreamModuleStreamingTest {
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
         assertEquals(0, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -484,7 +485,7 @@ public class UpstreamModuleStreamingTest {
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
         assertEquals(0, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(EXPECTED_BANDWIDTH, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -500,7 +501,7 @@ public class UpstreamModuleStreamingTest {
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
         Event event = new Event(10, upstreamModule, sampleV2XMessage);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 0;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 0L;
 
         // RUN
         upstreamModule.processEvent(event);
@@ -514,7 +515,7 @@ public class UpstreamModuleStreamingTest {
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -530,7 +531,7 @@ public class UpstreamModuleStreamingTest {
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
         Event event = new Event(10, upstreamModule, sampleV2XMessage);
-        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 0;
+        ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = 0L;
 
         CellConfiguration cellConfiguration = SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0");
         cellConfiguration.consumeUplink(Long.MAX_VALUE);
@@ -547,7 +548,7 @@ public class UpstreamModuleStreamingTest {
                 Arrays.asList(NegativeAckReason.CHANNEL_CAPACITY_EXCEEDED, NegativeAckReason.NODE_CAPACITY_EXCEEDED);
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
-        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(0, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
         assertEquals(0, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
     }
 
@@ -579,7 +580,7 @@ public class UpstreamModuleStreamingTest {
         List<NegativeAckReason> nackReasons = Arrays.asList(NegativeAckReason.NODE_DEACTIVATED);
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
-        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
     }
 
@@ -633,7 +634,7 @@ public class UpstreamModuleStreamingTest {
         List<NegativeAckReason> nackReasons = Collections.singletonList(NegativeAckReason.NODE_DEACTIVATED);
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
-        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
         assertEquals(Long.MAX_VALUE, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
     }
 

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleTest.java
@@ -186,7 +186,7 @@ public class UpstreamModuleTest {
         checkResultMessage(resultMessage, 2240 * DATA.BIT, 10 * TIME.SECOND, (long) (10.2 * TIME.SECOND));
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals((21000 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals((21000 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -219,7 +219,7 @@ public class UpstreamModuleTest {
         checkResultMessage(resultMessage, 2240 * DATA.BIT, 10 * TIME.SECOND, (long) (10.2 * TIME.SECOND));
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals((3000 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals((3000 - 2240) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -252,7 +252,7 @@ public class UpstreamModuleTest {
         checkResultMessage(resultMessage, 1120, 10 * TIME.SECOND, (long) (10.4 * TIME.SECOND));
 
         assertEquals((2240 - 1120) * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -284,7 +284,7 @@ public class UpstreamModuleTest {
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
         assertEquals(400 * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(600 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(600 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -320,7 +320,7 @@ public class UpstreamModuleTest {
 
         assertEquals((Long.MAX_VALUE - expectedBandwidth) * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0")
                 .getAvailableUplinkBitrate());
-        assertEquals((21000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals((21000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
 
         // FREE
         // SETUP
@@ -331,7 +331,7 @@ public class UpstreamModuleTest {
 
         // ASSERT
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -370,7 +370,7 @@ public class UpstreamModuleTest {
                 (Long.MAX_VALUE - expectedBandwidth) * DATA.BIT,
                 SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate()
         );
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
 
     }
 
@@ -412,7 +412,7 @@ public class UpstreamModuleTest {
                 (Long.MAX_VALUE - expectedBandwidth) * DATA.BIT,
                 SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate()
         );
-        assertEquals((21000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals((21000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -449,7 +449,7 @@ public class UpstreamModuleTest {
                 (Long.MAX_VALUE - expectedBandwidth) * DATA.BIT,
                 SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate()
         );
-        assertEquals((21000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals((21000 - expectedBandwidth) * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -479,7 +479,7 @@ public class UpstreamModuleTest {
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -512,7 +512,7 @@ public class UpstreamModuleTest {
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(200 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(200 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -541,7 +541,7 @@ public class UpstreamModuleTest {
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -573,7 +573,7 @@ public class UpstreamModuleTest {
                 Arrays.asList(NegativeAckReason.CHANNEL_CAPACITY_EXCEEDED, NegativeAckReason.NODE_CAPACITY_EXCEEDED);
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
-        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(0L, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
         assertEquals(0L, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
     }
 
@@ -604,7 +604,7 @@ public class UpstreamModuleTest {
         List<NegativeAckReason> nackReasons = Arrays.asList(NegativeAckReason.NODE_DEACTIVATED);
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
-        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
     }
 
@@ -659,7 +659,7 @@ public class UpstreamModuleTest {
         List<NegativeAckReason> nackReasons = Collections.singletonList(NegativeAckReason.NODE_DEACTIVATED);
         checkRtiMessages(nackReasons, sampleV2XMessage);
 
-        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
         assertEquals(Long.MAX_VALUE * DATA.BIT, SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0").getAvailableUplinkBitrate());
     }
 
@@ -716,7 +716,7 @@ public class UpstreamModuleTest {
 
         // ASSERT
         assertEquals(400 * DATA.BIT, cellConfiguration.getAvailableUplinkBitrate());
-        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity);
+        assertEquals(21000 * DATA.BIT, ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity.longValue());
     }
 
 

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/utility/CapacityUtilityTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/utility/CapacityUtilityTest.java
@@ -197,48 +197,48 @@ public class CapacityUtilityTest {
 
         CapacityUtility.consumeCapacity(TransmissionMode.UplinkUnicast, networkConfig.globalNetwork, nodeConfig, 200 * DATA.BIT);
         assertEquals(1800 * DATA.BIT, nodeConfig.getAvailableUplinkBitrate());
-        assertEquals(22800 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity);
+        assertEquals(22800 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity.longValue());
 
         CapacityUtility.consumeCapacity(TransmissionMode.DownlinkUnicast, networkConfig.globalNetwork, nodeConfig, 300 * DATA.BIT);
         assertEquals(700 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
-        assertEquals(41700 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity);
+        assertEquals(41700 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity.longValue());
 
         CapacityUtility.consumeCapacity(TransmissionMode.DownlinkMulticast, networkConfig.globalNetwork, nodeConfig, 400 * DATA.BIT);
         assertEquals(700 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
-        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity);
+        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity.longValue());
 
         // consume negative capacity (should not change the actual capacity)
         CapacityUtility.consumeCapacity(TransmissionMode.UplinkUnicast, networkConfig.globalNetwork, nodeConfig, -200 * DATA.BIT);
         assertEquals(1800 * DATA.BIT, nodeConfig.getAvailableUplinkBitrate());
-        assertEquals(22800 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity);
+        assertEquals(22800 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity.longValue());
 
         CapacityUtility.consumeCapacity(TransmissionMode.DownlinkUnicast, networkConfig.globalNetwork, nodeConfig, -200 * DATA.BIT);
         assertEquals(700 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
-        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity);
+        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity.longValue());
 
         CapacityUtility.consumeCapacity(TransmissionMode.DownlinkMulticast, networkConfig.globalNetwork, nodeConfig, -200 * DATA.BIT);
         assertEquals(700 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
-        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity);
+        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity.longValue());
 
         // check null
         CapacityUtility.consumeCapacity(null, networkConfig.globalNetwork, nodeConfig, 200 * DATA.BIT);
         assertEquals(700 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
-        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity);
+        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity.longValue());
 
         CapacityUtility.consumeCapacity(TransmissionMode.DownlinkUnicast, null, nodeConfig, 200 * DATA.BIT);
         assertEquals(700 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
-        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity);
+        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity.longValue());
 
         CapacityUtility.consumeCapacity(TransmissionMode.DownlinkUnicast, networkConfig.globalNetwork, null, 200 * DATA.BIT);
         assertEquals(700 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
-        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity);
+        assertEquals(41300 * DATA.BIT, networkConfig.globalNetwork.downlink.capacity.longValue());
 
         // consume more capacity as available
         CapacityUtility.consumeCapacity(TransmissionMode.DownlinkUnicast, networkConfig.globalNetwork, nodeConfig, 800 * DATA.BIT);
         assertEquals(-100 * DATA.BIT, nodeConfig.getAvailableDownlinkBitrate());
 
         CapacityUtility.consumeCapacity(TransmissionMode.UplinkUnicast, networkConfig.globalNetwork, nodeConfig, 23000 * DATA.BIT);
-        assertEquals(-200 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity);
+        assertEquals(-200 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -250,7 +250,7 @@ public class CapacityUtilityTest {
         RegionCapacityUtility.freeCapacityUp(networkConfig.globalNetwork, 500 * DATA.BIT);
 
         assertEquals(1700 * DATA.BIT, nodeConfig.getAvailableUplinkBitrate());
-        assertEquals(22700 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity);
+        assertEquals(22700 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity.longValue());
         try {
             NodeCapacityUtility.freeCapacityUp(nodeConfig, 800 * DATA.BIT);
             //noinspection ConstantConditions
@@ -263,7 +263,7 @@ public class CapacityUtilityTest {
         NodeCapacityUtility.freeCapacityUp(nodeConfig, 500 * DATA.BIT);
         RegionCapacityUtility.freeCapacityUp(networkConfig.globalNetwork, 500 * DATA.BIT);
         assertEquals(2000 * DATA.BIT, nodeConfig.getAvailableUplinkBitrate());
-        assertEquals(23000 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity);
+        assertEquals(23000 * DATA.BIT, networkConfig.globalNetwork.uplink.capacity.longValue());
     }
 
     @Test
@@ -335,8 +335,8 @@ public class CapacityUtilityTest {
     public void capacityHandlingForServers() {
         CNetwork networkConfig = configRule.getNetworkConfig();
         CNetworkProperties serverRegion = networkConfig.servers.get(0);
-        assertEquals(serverRegion.downlink.capacity, Long.MAX_VALUE);
-        assertEquals(serverRegion.uplink.capacity, Long.MAX_VALUE);
+        assertEquals(serverRegion.downlink.capacity.longValue(), Long.MAX_VALUE);
+        assertEquals(serverRegion.uplink.capacity.longValue(), Long.MAX_VALUE);
         assertEquals(
                 CapacityUtility.availableCapacity(TransmissionMode.DownlinkUnicast, serverRegion,
                         serverNodeConfig0), serverNodeConfig0.getAvailableDownlinkBitrate()
@@ -360,7 +360,7 @@ public class CapacityUtilityTest {
                 CapacityUtility.availableCapacity(TransmissionMode.DownlinkUnicast, serverRegion,
                         serverNodeConfig0), serverNodeConfig1.getAvailableDownlinkBitrate() - consumedBandwidth
         ); // capacity should be consumed up
-        assertEquals(serverRegion.downlink.capacity, Long.MAX_VALUE);
+        assertEquals(serverRegion.downlink.capacity.longValue(), Long.MAX_VALUE);
         RegionCapacityUtility.freeCapacityDown(serverRegion, consumedBandwidth);
         NodeCapacityUtility.freeCapacityDown(serverNodeConfig0, consumedBandwidth);
         assertEquals(
@@ -374,7 +374,7 @@ public class CapacityUtilityTest {
                 CapacityUtility.availableCapacity(TransmissionMode.UplinkUnicast, serverRegion,
                         serverNodeConfig0), serverNodeConfig1.getAvailableUplinkBitrate() - consumedBandwidth
         ); // capacity should be consumed up
-        assertEquals(serverRegion.uplink.capacity, Long.MAX_VALUE);
+        assertEquals(serverRegion.uplink.capacity.longValue(), Long.MAX_VALUE);
         RegionCapacityUtility.freeCapacityUp(serverRegion, consumedBandwidth);
         NodeCapacityUtility.freeCapacityUp(serverNodeConfig0, consumedBandwidth);
         assertEquals(

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/utility/RegionCapacityUtilityTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/utility/RegionCapacityUtilityTest.java
@@ -78,8 +78,8 @@ public class RegionCapacityUtilityTest {
         // The normal, easy case. Enough bandwidth available.
         RegionCapacityUtility.consumeCapacityDown(defaultRegion, 2500 * DATA.BIT);
         RegionCapacityUtility.consumeCapacityUp(defaultRegion, 1500 * DATA.BIT);
-        assertEquals((capacityDown - 2500) * DATA.BIT, defaultRegion.downlink.capacity);
-        assertEquals((capacityUp - 1500) * DATA.BIT, defaultRegion.uplink.capacity);
+        assertEquals((capacityDown - 2500) * DATA.BIT, defaultRegion.downlink.capacity.longValue());
+        assertEquals((capacityUp - 1500) * DATA.BIT, defaultRegion.uplink.capacity.longValue());
 
         assertTrue(RegionCapacityUtility.isCapacitySufficientDown(defaultRegion, 1000 * DATA.BIT));
         assertTrue(RegionCapacityUtility.isCapacitySufficientUp(defaultRegion, 1000 * DATA.BIT));
@@ -89,8 +89,8 @@ public class RegionCapacityUtilityTest {
         // This can happen when a message has a packet loss and needs to consumeCapacity anyway.
         RegionCapacityUtility.consumeCapacityDown(defaultRegion, 40000 * DATA.BIT);
         RegionCapacityUtility.consumeCapacityUp(defaultRegion, 40000 * DATA.BIT);
-        assertEquals((capacityDown - 2500 - 40000) * DATA.BIT, defaultRegion.downlink.capacity);
-        assertEquals((capacityUp - 1500 - 40000) * DATA.BIT, defaultRegion.uplink.capacity);
+        assertEquals((capacityDown - 2500 - 40000) * DATA.BIT, defaultRegion.downlink.capacity.longValue());
+        assertEquals((capacityUp - 1500 - 40000) * DATA.BIT, defaultRegion.uplink.capacity.longValue());
 
         assertFalse(RegionCapacityUtility.isCapacitySufficientDown(defaultRegion, 1000 * DATA.BIT));
         assertFalse(RegionCapacityUtility.isCapacitySufficientUp(defaultRegion, 1000 * DATA.BIT));
@@ -98,7 +98,7 @@ public class RegionCapacityUtilityTest {
         // Try to free some bandwidth
         RegionCapacityUtility.freeCapacityDown(defaultRegion, 1500 * DATA.BIT);
         RegionCapacityUtility.freeCapacityUp(defaultRegion, 2500 * DATA.BIT);
-        assertEquals((capacityDown - 2500 - 40000 + 1500) * DATA.BIT, defaultRegion.downlink.capacity);
-        assertEquals((capacityUp - 1500 - 40000 + 2500) * DATA.BIT, defaultRegion.uplink.capacity);
+        assertEquals((capacityDown - 2500 - 40000 + 1500) * DATA.BIT, defaultRegion.downlink.capacity.longValue());
+        assertEquals((capacityUp - 1500 - 40000 + 2500) * DATA.BIT, defaultRegion.uplink.capacity.longValue());
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
@@ -23,6 +23,7 @@ import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.lib.enums.LaneChangeMode;
 import org.eclipse.mosaic.lib.enums.SpeedMode;
 import org.eclipse.mosaic.lib.enums.VehicleClass;
+import org.eclipse.mosaic.lib.math.MathUtils;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 
@@ -175,11 +176,11 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
         );
     }
 
-    Double deviateWithBounds(RandomNumberGenerator random, Double mean, double deviation) {
-        if (mean != null && Math.abs(deviation) > 0.0001) {
+    Double deviateWithBounds(RandomNumberGenerator random, Double mean, Double deviation) {
+        if (mean != null && deviation != null && Math.abs(deviation) > 0.0001) {
             double randomValue = random.nextGaussian(mean, deviation);
 
-            return Math.max(Math.min(mean + 2 * deviation, randomValue), mean - 2 * deviation);
+            return MathUtils.clamp(randomValue,  mean - 2 * deviation,  mean + 2 * deviation);
         }
         return mean;
     }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CParameterDeviations.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CParameterDeviations.java
@@ -20,15 +20,15 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class CParameterDeviations {
 
-    public double length = 0.0;
-    public double width = 0.0;
-    public double height = 0.0;
-    public double minGap = 0.0;
-    public double maxSpeed = 0.0;
-    public double speedFactor = 0.0;
-    public double accel = 0.0;
-    public double decel = 0.0;
-    public double tau = 0.0;
+    public Double length;
+    public Double width;
+    public Double height;
+    public Double minGap;
+    public Double maxSpeed;
+    public Double speedFactor;
+    public Double accel;
+    public Double decel;
+    public Double tau;
 
     public CParameterDeviations copy() {
         final CParameterDeviations copy = new CParameterDeviations();

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficsign/TrafficSign.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficsign/TrafficSign.java
@@ -126,7 +126,7 @@ public abstract class TrafficSign<T> implements Serializable {
      * @param visibility The visibility of the sign.
      */
     public TrafficSign setVisibility(double visibility) {
-        this.visibility = MathUtils.clamp(0, visibility, 1.0d);
+        this.visibility = MathUtils.clamp(visibility, 0, 1.0d);
         return this;
     }
 

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/FileUtils.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/FileUtils.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.mosaic.lib.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -49,7 +51,7 @@ public class FileUtils {
 
         final Set<File> matchingSet = new HashSet<>();
         while (maxDepth-- > 0) {
-            if (searchSet.size() > 0) {
+            if (!searchSet.isEmpty()) {
                 Set<File> newDirectorySet = new HashSet<>();
                 for (File f : searchSet) {
                     if (f.canRead() && acceptPredicate.test(f)) {
@@ -110,6 +112,19 @@ public class FileUtils {
      * Creates a new file in the given path and name. If the file already exists, a number suffix
      * is added to the actual file name.
      *
+     * @param path        the path to the file to create.
+     * @param extension   provides the file extension
+     * @param ignoreExist if {@code true}, no check is done and the file is returned as requested.
+     * @return the actual file object with the name having a suffix if already exists
+     */
+    public static File getIncrementFile(String path, String extension, boolean ignoreExist) throws IOException {
+        return getIncrementFile(new File(path), extension, ignoreExist);
+    }
+
+    /**
+     * Creates a new file in the given path and name. If the file already exists, a number suffix
+     * is added to the actual file name.
+     *
      * @param file        the file to create
      * @param ignoreExist if {@code true}, no check is done and the file is returned as requested.
      * @return the actual file object with the name having a suffix if already exists
@@ -121,6 +136,28 @@ public class FileUtils {
             int pos = filename.lastIndexOf('.');
             if (pos > 0) {
                 extension = filename.substring(pos);
+            }
+            return getIncrementFile(file, extension, false);
+        }
+        return file;
+    }
+
+    /**
+     * Creates a new file in the given path and name. If the file already exists, a number suffix
+     * is added to the actual file name.
+     *
+     * @param file        the file to create
+     * @param extension   provides the file extension
+     * @param ignoreExist if {@code true}, no check is done and the file is returned as requested.
+     * @return the actual file object with the name having a suffix if already exists
+     */
+    public static File getIncrementFile(File file, String extension, boolean ignoreExist) throws IOException {
+        if (file.exists() && !ignoreExist) {
+            if (!file.getName().endsWith(extension)) {
+                throw new IllegalArgumentException("Provided file does not end with provided extension.");
+            }
+            if (StringUtils.isNotEmpty(extension) && !extension.startsWith(".")) {
+                extension = "." + extension;
             }
 
             String pathWithoutExtension = file.getCanonicalPath();

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/gson/UnitFieldAdapter.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/gson/UnitFieldAdapter.java
@@ -29,6 +29,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -81,7 +84,8 @@ public class UnitFieldAdapter extends TypeAdapter<Double> {
 
     @Override
     public void write(JsonWriter out, Double param) throws IOException {
-        out.value(ObjectUtils.defaultIfNull(param, 0d) + " " + unit);
+        out.value(new DecimalFormat("#.#####", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+                .format(ObjectUtils.defaultIfNull(param, 0d)) + " " + unit);
     }
 
     @Override


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

Three minor changes:

### Cell network configuration field `capacity` is now of type `Long` instead `long`

* Previously: When exporting a `CNetwork` object to JSON, it always writes out the capacity as it was declared as a `long` primitive. When adding a server configuration to such object, which implicitly sets the capacity to `0`, the export also writes `"capacity": 0` to the JSON; (We want to this in scenario-convert to define a default server configuration). This leads to JSON file which cannot be read by the Cell Ambassador, as the JSON schema defines that server configurations are not allowed to define a capacity. There are several solutions:
  * Change the schema definition --> decided against it, I actually find it useful to have this in the schema)
  * Change the object structure and define a separate class for servers which do not declare a capacity field --> would be the cleanest solution, but also the most difficult as that would require a larger refactoring, which I don't want to tackle right before the release.
  * Change the field type from primitive type `long` to boxed type `Long` which allows `null`. Fields with `null` are not exported, which is what we want here. --> This solution was implemented, as it only required simple adjustments mostly in tests to convert the boxed type to the primitive type.

### Mapping prototype deviation fields are now of type `Double` instead of `double`.

* Main reason was that scenario convert created mapping_config files with a lot of `0.0` values. Using the boxed type `Double` instead gets rid of these.
* Furthermore, fields which use `UnitFieldAdapter` now cap the exported string by printing 5 decimal places at most. (e.g. `36.66666 m/s` instead of `36.666666666666 m/s`.

### Extending XML Utils

* XmlUtils adds a suffix to file-names if they already existing. That did not work for files with a file extension consisting of two elements, such as `.rou.xml` or `.net.xml`. This is now solved by allowing the actual file extension to be passed to the method `getIncrementFile(...)`.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves issue #<eclipse-mosaic-issue> / internal issue <internal-issue>
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [ ] You have read CONTRIBUTING.md carefully.
- [ ] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [ ] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [ ] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [ ] `origin/main` has been merged into your Fork.
- [ ] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

