### PR TITLE
fix: Use Unix-style File Separator in Run Config

### DIFF
--- a/rti/mosaic-starter/MosaicStarter.run.xml
+++ b/rti/mosaic-starter/MosaicStarter.run.xml
@@ -3,7 +3,7 @@
     <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
     <option name="MAIN_CLASS_NAME" value="org.eclipse.mosaic.starter.MosaicStarter" />
     <module name="mosaic-starter" />
-    <option name="PROGRAM_PARAMETERS" value="-c ..\..\bundle\src\assembly\resources\scenarios\HelloWorld\scenario_config.json" />
+    <option name="PROGRAM_PARAMETERS" value="-c ../../bundle/src/assembly/resources/scenarios/HelloWorld/scenario_config.json" />
     <option name="WORKING_DIRECTORY" value="$MODULE_WORKING_DIR$" />
     <extension name="coverage">
       <pattern>


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

- This PR allows the `MosaicStarter` run-config to work out of the box, by replacing windows-style (i.e., `\`) separators with unix-style separators (i.e., `/`)
- Under windows both separators should work fine

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Relates to internal issue 818
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

- yes, adjustments are already going on

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

