### PR TITLE
feat(sumo): support SUMO 1.23.0

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/LibSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/LibSumoAmbassador.java
@@ -34,7 +34,7 @@ import java.nio.file.Paths;
  */
 public class LibSumoAmbassador extends SumoAmbassador {
 
-    private static final String VALID_LIBSUMO_VERSIONS = "1\\.(19|20|21)\\.";
+    private static final String VALID_LIBSUMO_VERSIONS = "1\\.(23)\\.";
 
     public LibSumoAmbassador(AmbassadorParameter ambassadorParameter) {
         super(ambassadorParameter);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
@@ -47,6 +47,7 @@ public enum SumoVersion {
     SUMO_1_20_x("1.20.*", TraciVersion.API_21),
     SUMO_1_21_x("1.21.*", TraciVersion.API_21),
     SUMO_1_22_x("1.22.*", TraciVersion.API_21),
+    SUMO_1_23_x("1.23.*", TraciVersion.API_22),
 
     /**
      * the lowest version supported by this client.
@@ -56,7 +57,7 @@ public enum SumoVersion {
     /**
      * the highest version supported by this client.
      */
-    HIGHEST(SUMO_1_22_x.sumoVersion, SUMO_1_22_x.traciVersion);
+    HIGHEST(SUMO_1_23_x.sumoVersion, SUMO_1_23_x.traciVersion);
 
     private final String sumoVersion;
     private final TraciVersion traciVersion;

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/TraciVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/TraciVersion.java
@@ -22,6 +22,7 @@ public enum TraciVersion {
     API_19(19),
     API_20(20),
     API_21(21),
+    API_22(22),
 
     /**
      * the lowest version supported by this client.
@@ -31,7 +32,7 @@ public enum TraciVersion {
     /**
      * the highest version supported by this client.
      */
-    HIGHEST(API_21.getApiVersion());
+    HIGHEST(API_22.getApiVersion());
 
     private final int apiVersion;
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleSubscribe.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleSubscribe.java
@@ -26,6 +26,11 @@ import org.eclipse.mosaic.rti.api.InternalFederateException;
 public interface VehicleSubscribe {
 
     /**
+     * Number of next stops to fetch via subscription.
+     */
+    int FETCH_NUM_NEXT_STOPS = 1;
+
+    /**
      * This method executes the command with the given arguments in order to subscribe the vehicle to the application.
      *
      * @param bridge    Connection to SUMO.

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleSubscribe.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleSubscribe.java
@@ -26,9 +26,9 @@ import org.eclipse.mosaic.rti.api.InternalFederateException;
 public interface VehicleSubscribe {
 
     /**
-     * Number of next stops to fetch via subscription.
+     * Number of next stops to fetch via subscription. (0 == unlimited)
      */
-    int FETCH_NUM_NEXT_STOPS = 1;
+    int FETCH_NUM_NEXT_STOPS = 0;
 
     /**
      * This method executes the command with the given arguments in order to subscribe the vehicle to the application.

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleSubscribe.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleSubscribe.java
@@ -26,19 +26,20 @@ import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieve
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_EMISSIONS_NOX;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_EMISSIONS_PMX;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_FOLLOWER;
-import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LINE;
-import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_NEXT_STOPS;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LANE_INDEX;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LANE_POSITION;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LATERAL_LANE_POSITION;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LEADER;
+import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LINE;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_MIN_GAP;
+import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_NEXT_STOPS;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_POSITION_3D;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_ROAD_ID;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_ROUTE_ID;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_SIGNAL_STATES;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_SLOPE;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_SPEED;
+import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_STOPS;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_STOP_STATE;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
@@ -124,6 +125,7 @@ public class VehicleSubscribe
 
         if (subscriptionCategories.contains(CSumo.SUBSCRIPTION_TRAINS)) {
             Collections.addAll(subscriptionCodes, VAR_NEXT_STOPS);
+            Collections.addAll(subscriptionCodes, VAR_STOPS);
             Collections.addAll(subscriptionCodes, VAR_LINE);
         }
         return subscriptionCodes;
@@ -184,6 +186,9 @@ public class VehicleSubscribe
                     if (subscriptionVar instanceof SumoVar.WithParam) {
                         write.writeByte(TraciDatatypes.DOUBLE);
                         write.writeDouble(((SumoVar.WithParam) subscriptionVar).getValue());
+                    } else if (subscriptionVar instanceof SumoVar.WithIntParam) {
+                        write.writeByte(TraciDatatypes.INTEGER);
+                        write.writeInt(((SumoVar.WithIntParam) subscriptionVar).getValue());
                     }
                 });
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleSubscribe.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleSubscribe.java
@@ -183,12 +183,12 @@ public class VehicleSubscribe
 
                     write.writeByte(subscriptionVar.var);
 
-                    if (subscriptionVar instanceof SumoVar.WithParam) {
+                    if (subscriptionVar instanceof SumoVar.WithDoubleParam doubleParam) {
                         write.writeByte(TraciDatatypes.DOUBLE);
-                        write.writeDouble(((SumoVar.WithParam) subscriptionVar).getValue());
-                    } else if (subscriptionVar instanceof SumoVar.WithIntParam) {
+                        write.writeDouble(doubleParam.getValue());
+                    } else if (subscriptionVar instanceof SumoVar.WithIntParam intParam) {
                         write.writeByte(TraciDatatypes.INTEGER);
-                        write.writeInt(((SumoVar.WithIntParam) subscriptionVar).getValue());
+                        write.writeInt(intParam.getValue());
                     }
                 });
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleState.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleState.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.mosaic.fed.sumo.bridge.traci.constants;
 
+import static org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSubscribe.FETCH_NUM_NEXT_STOPS;
+
 import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
 
 public class CommandRetrieveVehicleState {
@@ -47,9 +49,9 @@ public class CommandRetrieveVehicleState {
 
     public final static SumoVar VAR_LATERAL_LANE_POSITION = SumoVar.var(0xb8);
 
-    public static final SumoVar VAR_LEADER = SumoVar.WithParam.var(0x68, 100d);
+    public static final SumoVar VAR_LEADER = SumoVar.WithDoubleParam.var(0x68, 100d);
 
-    public static final SumoVar VAR_FOLLOWER = SumoVar.WithParam.var(0x78, 100d);
+    public static final SumoVar VAR_FOLLOWER = SumoVar.WithDoubleParam.var(0x78, 100d);
 
     public final static SumoVar VAR_DISTANCE = SumoVar.var(0x84);
 
@@ -70,7 +72,7 @@ public class CommandRetrieveVehicleState {
     public final static SumoVar VAR_EMISSIONS_ELECTRICITY = SumoVar.var(0x71);
 
     public final static SumoVar VAR_NEXT_STOPS = SumoVar.varDeprecated(0x73, TraciVersion.API_22);
-    public final static SumoVar VAR_STOPS = SumoVar.WithIntParam.varSince(0x74, 10, TraciVersion.API_22);
+    public final static SumoVar VAR_STOPS = SumoVar.WithIntParam.varSince(0x74, FETCH_NUM_NEXT_STOPS, TraciVersion.API_22);
     public final static SumoVar VAR_LINE = SumoVar.var(0xbd);
 
     public final static SumoVar VAR_STOP_STATE = SumoVar.var(0xb5);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleState.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleState.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.mosaic.fed.sumo.bridge.traci.constants;
 
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+
 public class CommandRetrieveVehicleState {
 
     public final static int COMMAND = 0xa4;
@@ -67,7 +69,8 @@ public class CommandRetrieveVehicleState {
 
     public final static SumoVar VAR_EMISSIONS_ELECTRICITY = SumoVar.var(0x71);
 
-    public final static SumoVar VAR_NEXT_STOPS = SumoVar.var(0x73);
+    public final static SumoVar VAR_NEXT_STOPS = SumoVar.varDeprecated(0x73, TraciVersion.API_22);
+    public final static SumoVar VAR_STOPS = SumoVar.WithIntParam.varSince(0x74, 10, TraciVersion.API_22);
     public final static SumoVar VAR_LINE = SumoVar.var(0xbd);
 
     public final static SumoVar VAR_STOP_STATE = SumoVar.var(0xb5);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/SumoVar.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/SumoVar.java
@@ -63,11 +63,11 @@ public class SumoVar {
                 && (deprecatedSince == null || currentVersion.getApiVersion() < deprecatedSince.getApiVersion());
     }
 
-    public static class WithParam extends SumoVar {
+    public static class WithDoubleParam extends SumoVar {
 
         private Double value;
 
-        private WithParam(int var, Double value, TraciVersion since, TraciVersion deprecatedSince) {
+        private WithDoubleParam(int var, Double value, TraciVersion since, TraciVersion deprecatedSince) {
             super(var, since, deprecatedSince);
             this.value = value;
         }
@@ -76,8 +76,8 @@ public class SumoVar {
             return value;
         }
 
-        static SumoVar.WithParam var(int var, double value) {
-            return new WithParam(var, value, TraciVersion.LOWEST, null);
+        static WithDoubleParam var(int var, double value) {
+            return new WithDoubleParam(var, value, TraciVersion.LOWEST, null);
         }
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/SumoVar.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/SumoVar.java
@@ -97,5 +97,9 @@ public class SumoVar {
         static SumoVar.WithIntParam var(int var, int value) {
             return new WithIntParam(var, value, TraciVersion.LOWEST, null);
         }
+
+        static SumoVar.WithIntParam varSince(int var, int value, TraciVersion since) {
+            return new WithIntParam(var, value, since, null);
+        }
     }
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/VehicleSubscriptionTraciReader.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/VehicleSubscriptionTraciReader.java
@@ -38,7 +38,8 @@ public class VehicleSubscriptionTraciReader extends AbstractSubscriptionTraciRea
         LeadingVehicleReader leadingVehicleReader = new LeadingVehicleReader();
         getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_LEADER.var, leadingVehicleReader);
         getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_FOLLOWER.var, leadingVehicleReader);
-        getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_NEXT_STOPS.var, new StoppingPlaceReader());
+        getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_NEXT_STOPS.var, new StoppingPlaceReader(true));
+        getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_STOPS.var, new StoppingPlaceReader());
     }
 
     @Override
@@ -105,6 +106,8 @@ public class VehicleSubscriptionTraciReader extends AbstractSubscriptionTraciRea
         } else if (varId == CommandRetrieveVehicleState.VAR_MIN_GAP.var) {
             result.minGap = (double) varValue;
         } else if (varId == CommandRetrieveVehicleState.VAR_NEXT_STOPS.var) {
+            result.nextStops = (List<PtVehicleData.StoppingPlace>) varValue;
+        } else if (varId == CommandRetrieveVehicleState.VAR_STOPS.var) {
             result.nextStops = (List<PtVehicleData.StoppingPlace>) varValue;
         } else if (varId == CommandRetrieveVehicleState.VAR_LINE.var) {
             result.line = (String) varValue;

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
@@ -286,7 +286,12 @@ public class TraciTest {
         traci.getVehicleControl().slowDown("veh_0", 3d, 4 * TIME.SECOND);
 
         // ASSERT (by checking if slow down speed is reached after given duration)
-        traci.getSimulationControl().simulateUntil(9 * TIME.SECOND);
+        if (traci.getCurrentVersion().isGreaterOrEqualThan(SumoVersion.SUMO_1_23_x)) {
+            traci.getSimulationControl().simulateUntil(8 * TIME.SECOND);
+        } else {
+            // in previous SUMO versions, there was a bug which would require duration + stepsize to reach wanted speed.
+            traci.getSimulationControl().simulateUntil(9 * TIME.SECOND);
+        }
         assertEquals(3d, traci.getSimulationControl().getLastKnownVehicleData("veh_0").getSpeed(), 0.2d);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.slf4j>2.0.12</version.slf4j><!-- 2.0.12 is approved #13344 -->
         <version.sqlite-jdbc>3.42.0.0</version.sqlite-jdbc><!-- 3.42.0.0 is approved in #9089 -->
         <!-- note, when upgrading, the field LibSumoAmbassador#VALID_LIBSUMO_VERSIONS needs to be changed too -->
-        <version.libsumo>1.21.0</version.libsumo>
+        <version.libsumo>1.23.0</version.libsumo>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* TraCI version changed to 22
* `Vehicle.GetNextStops()` (`0x73`) has been replaced with `Vehicle.GetStops()` (`0x74`), which takes a positive int parameter for the number of next stops to retrieve. This command also returns more fields, therefore, the `StoppingPlaceReader` has been adapted to work with both variants. For SUMO versions below 1.23.0, the old subscription variable `0x73` is used, for anything >= 1.23.0, the `0x74` variable is used.
* With 1.23.0, a bug in `slowDown` has been resolved, so that the target speed is reached in the correct time (was duration + timestep previously). That required the slowDown test to be adjusted.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 1048
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No, versions on website are adjusted with the next MOSAIC release.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

