### PR TITLE
chore(routing): upgrade to GraphHopper 10.2

### DIFF
--- a/NOTICE-THIRD-PARTY.md
+++ b/NOTICE-THIRD-PARTY.md
@@ -93,26 +93,26 @@ FindBugs-jsr305 (3.0.2)
  * Source: https://code.google.com/p/jsr-305/
 
 
-GraphHopper Core (8.0)
+GraphHopper Core (10.2)
 
  * License: Apache-2.0
- * Maven artifact: `com.graphhopper:graphhopper-core:8.0`
+ * Maven artifact: `com.graphhopper:graphhopper-core:10.2`
  * Project: https://www.graphhopper.com/graphhopper-core
  * Source: https://github.com/graphhopper/graphhopper/graphhopper-core
 
 
-GraphHopper Reader for Gtfs Data (8.0)
+GraphHopper Reader for Gtfs Data (10.2)
 
  * License: Apache-2.0
- * Maven artifact: `com.graphhopper:graphhopper-reader-gtfs:8.0`
+ * Maven artifact: `com.graphhopper:graphhopper-reader-gtfs:10.2`
  * Project: https://www.graphhopper.com/graphhopper-reader-gtfs
  * Source: https://github.com/graphhopper/graphhopper/graphhopper-reader-gtfs
 
 
-GraphHopper Web API (8.0)
+GraphHopper Web API (10.2)
 
  * License: Apache-2.0
- * Maven artifact: `com.graphhopper:graphhopper-web-api:8.0`
+ * Maven artifact: `com.graphhopper:graphhopper-web-api:10.2`
  * Project: https://www.graphhopper.com/graphhopper-web-api
  * Source: https://github.com/graphhopper/graphhopper/graphhopper-web-api
 

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
@@ -29,15 +29,18 @@ import org.eclipse.mosaic.lib.routing.RoutingCostFunction;
 import org.eclipse.mosaic.lib.routing.RoutingPosition;
 import org.eclipse.mosaic.lib.routing.RoutingRequest;
 import org.eclipse.mosaic.lib.routing.graphhopper.algorithm.RoutingAlgorithmFactory;
+import org.eclipse.mosaic.lib.routing.graphhopper.profile.BikeProfile;
+import org.eclipse.mosaic.lib.routing.graphhopper.profile.CarProfile;
+import org.eclipse.mosaic.lib.routing.graphhopper.profile.RoutingProfile;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.DatabaseGraphLoader;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.GraphhopperToDatabaseMapper;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.OptionalTurnCostProvider;
+import org.eclipse.mosaic.lib.routing.graphhopper.util.RoutingProfileManager;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncoding;
-import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncodingManager;
+import org.eclipse.mosaic.lib.routing.graphhopper.util.WayTypeEncoder;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.graphhopper.config.Profile;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.RoutingAlgorithm;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
@@ -60,7 +63,6 @@ import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.PointList;
-import com.graphhopper.util.TurnCostsConfig;
 import com.graphhopper.util.shapes.GHPoint;
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import org.apache.commons.lang3.ObjectUtils;
@@ -69,24 +71,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 @SuppressWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Static fields kept public and adjustable for user customization")
 public class GraphHopperRouting {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphHopperRouting.class);
 
-    public static final Profile PROFILE_CAR = new Profile("car").setTurnCostsConfig(new TurnCostsConfig());
-
-    public static final Profile PROFILE_BIKE = new Profile("bike").setTurnCostsConfig(null);
-
-    public static final List<Profile> PROFILES = Collections.unmodifiableList(Lists.newArrayList(
-            PROFILE_CAR, PROFILE_BIKE
-    ));
+    public static final Collection<Supplier<RoutingProfile>> PROFILES = List.of(
+            CarProfile::new,
+            BikeProfile::new
+    );
 
     /**
      * The minimum number of alternatives to calculate when alternative routes have been requested.
@@ -140,7 +140,7 @@ public class GraphHopperRouting {
 
     private final GraphhopperToDatabaseMapper graphMapper;
     private final Database db;
-    private final VehicleEncodingManager encoding;
+    private final RoutingProfileManager profileManager;
     private final BaseGraph graph;
     private final LocationIndex locationIndex;
 
@@ -148,7 +148,7 @@ public class GraphHopperRouting {
         this.db = db;
 
         graphMapper = new GraphhopperToDatabaseMapper();
-        encoding = new VehicleEncodingManager(PROFILES);
+        profileManager = new RoutingProfileManager(PROFILES);
 
         graph = createGraphFromDatabase(db);
         locationIndex = createLocationIndex();
@@ -159,15 +159,15 @@ public class GraphHopperRouting {
 
     private BaseGraph createGraphFromDatabase(Database db) {
         final BaseGraph graph = new BaseGraph
-                .Builder(encoding.getEncodingManager())
+                .Builder(profileManager.getEncodingManager())
                 .setDir(new RAMDirectory())
                 .set3D(true)
-                .withTurnCosts(encoding.getEncodingManager().needsTurnCostsSupport())
+                .withTurnCosts(profileManager.getEncodingManager().needsTurnCostsSupport())
                 .setSegmentSize(-1)
                 .build();
 
         final DatabaseGraphLoader reader = new DatabaseGraphLoader(db);
-        reader.initialize(graph, encoding, graphMapper);
+        reader.initialize(graph, profileManager, graphMapper);
         reader.loadGraph();
         LOG.info("nodes: {}, edges: {}", graph.getNodes(), graph.getEdges());
         return graph;
@@ -189,9 +189,9 @@ public class GraphHopperRouting {
 
     private List<PrepareRoutingSubnetworks.PrepareJob> buildSubnetworkRemovalJobs() {
         List<PrepareRoutingSubnetworks.PrepareJob> jobs = new ArrayList<>();
-        for (Profile profile : encoding.getAllProfiles()) {
+        for (RoutingProfile profile : profileManager.getAllProfiles()) {
             Weighting weighting = createWeighting(profile, RoutingCostFunction.Fastest, false);
-            jobs.add(new PrepareRoutingSubnetworks.PrepareJob(encoding.getVehicleEncoding(profile.getName()).subnetwork(), weighting));
+            jobs.add(new PrepareRoutingSubnetworks.PrepareJob(profile.getVehicleEncoding().subnetwork(), weighting));
         }
         return jobs;
     }
@@ -201,13 +201,13 @@ public class GraphHopperRouting {
             throw new IllegalStateException("Load database at first");
         }
 
-        final Profile profile;
+        final RoutingProfile profile;
         if (routingRequest.getRoutingParameters().getVehicleClass() == VehicleClass.Bicycle) {
-            profile = PROFILE_BIKE;
+            profile = profileManager.getRoutingProfile(BikeProfile.NAME);
         } else {
-            profile = PROFILE_CAR;
+            profile = profileManager.getRoutingProfile(CarProfile.NAME);
         }
-        final VehicleEncoding vehicleEncoding = encoding.getVehicleEncoding(profile.getName());
+        final VehicleEncoding vehicleEncoding = profile.getVehicleEncoding();
 
         final RoutingPosition source = routingRequest.getSource();
         final RoutingPosition target = routingRequest.getTarget();
@@ -262,13 +262,14 @@ public class GraphHopperRouting {
         return result;
     }
 
-    private Weighting createWeighting(Profile profile, RoutingCostFunction costFunction, boolean withTurnCosts) {
-        final VehicleEncoding vehicleEncoding = encoding.getVehicleEncoding(profile.getName());
+    private Weighting createWeighting(RoutingProfile profile, RoutingCostFunction costFunction, boolean withTurnCosts) {
+        final VehicleEncoding vehicleEncoding = profile.getVehicleEncoding();
         final OptionalTurnCostProvider turnCostProvider = new OptionalTurnCostProvider(vehicleEncoding, graph.getTurnCostStorage());
         if (!withTurnCosts) {
             turnCostProvider.disableTurnCosts();
         }
-        return new GraphHopperWeighting(vehicleEncoding, encoding.wayType(), turnCostProvider, graphMapper)
+        WayTypeEncoder wayTypeEncoder = profileManager.getEncodingManager().getEncodedValue(WayTypeEncoder.KEY, WayTypeEncoder.class);
+        return new GraphHopperWeighting(vehicleEncoding, wayTypeEncoder, turnCostProvider, graphMapper)
                 .setRoutingCostFunction(ObjectUtils.defaultIfNull(costFunction, RoutingCostFunction.Default));
     }
 

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
@@ -60,6 +60,7 @@ import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.PointList;
+import com.graphhopper.util.TurnCostsConfig;
 import com.graphhopper.util.shapes.GHPoint;
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import org.apache.commons.lang3.ObjectUtils;
@@ -79,9 +80,9 @@ public class GraphHopperRouting {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphHopperRouting.class);
 
-    public static final Profile PROFILE_CAR = new Profile("car").setVehicle("car").setTurnCosts(true);
+    public static final Profile PROFILE_CAR = new Profile("car").setTurnCostsConfig(new TurnCostsConfig());
 
-    public static final Profile PROFILE_BIKE = new Profile("bike").setVehicle("bike").setTurnCosts(false);
+    public static final Profile PROFILE_BIKE = new Profile("bike").setTurnCostsConfig(null);
 
     public static final List<Profile> PROFILES = Collections.unmodifiableList(Lists.newArrayList(
             PROFILE_CAR, PROFILE_BIKE
@@ -190,7 +191,7 @@ public class GraphHopperRouting {
         List<PrepareRoutingSubnetworks.PrepareJob> jobs = new ArrayList<>();
         for (Profile profile : encoding.getAllProfiles()) {
             Weighting weighting = createWeighting(profile, RoutingCostFunction.Fastest, false);
-            jobs.add(new PrepareRoutingSubnetworks.PrepareJob(encoding.getVehicleEncoding(profile.getVehicle()).subnetwork(), weighting));
+            jobs.add(new PrepareRoutingSubnetworks.PrepareJob(encoding.getVehicleEncoding(profile.getName()).subnetwork(), weighting));
         }
         return jobs;
     }
@@ -206,7 +207,7 @@ public class GraphHopperRouting {
         } else {
             profile = PROFILE_CAR;
         }
-        final VehicleEncoding vehicleEncoding = encoding.getVehicleEncoding(profile.getVehicle());
+        final VehicleEncoding vehicleEncoding = encoding.getVehicleEncoding(profile.getName());
 
         final RoutingPosition source = routingRequest.getSource();
         final RoutingPosition target = routingRequest.getTarget();
@@ -262,7 +263,7 @@ public class GraphHopperRouting {
     }
 
     private Weighting createWeighting(Profile profile, RoutingCostFunction costFunction, boolean withTurnCosts) {
-        final VehicleEncoding vehicleEncoding = encoding.getVehicleEncoding(profile.getVehicle());
+        final VehicleEncoding vehicleEncoding = encoding.getVehicleEncoding(profile.getName());
         final OptionalTurnCostProvider turnCostProvider = new OptionalTurnCostProvider(vehicleEncoding, graph.getTurnCostStorage());
         if (!withTurnCosts) {
             turnCostProvider.disableTurnCosts();

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperWeighting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperWeighting.java
@@ -28,6 +28,8 @@ import com.graphhopper.routing.weighting.TurnCostProvider;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.EdgeIteratorState;
 
+import java.util.Objects;
+
 /**
  * A dynamic weight calculation. If an alternative travel time
  * on an edge is known, then this travel time will be used to weight
@@ -65,11 +67,8 @@ public class GraphHopperWeighting implements Weighting {
         }
         synchronized (edgePropertiesState) {
             edgePropertiesState.setCurrentEdgeIterator(edge, reverse);
-            if (routingCostFunction == null) {
-                return edge.getDistance() / edgePropertiesState.getSpeed();
-            } else {
-                return routingCostFunction.calculateCosts(edgePropertiesState);
-            }
+            return Objects.requireNonNullElse(routingCostFunction, RoutingCostFunction.Fastest)
+                    .calculateCosts(edgePropertiesState);
         }
     }
 

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/BikeProfile.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/BikeProfile.java
@@ -17,9 +17,7 @@ package org.eclipse.mosaic.lib.routing.graphhopper.profile;
 
 import com.google.common.collect.Lists;
 import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.VehiclePriority;
 import com.graphhopper.routing.ev.VehicleSpeed;
-import com.graphhopper.routing.util.PriorityCode;
 import com.graphhopper.routing.util.parsers.BikeAccessParser;
 import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
 import com.graphhopper.routing.util.parsers.TagParser;
@@ -33,8 +31,13 @@ public class BikeProfile extends RoutingProfile {
 
     public BikeProfile() {
         super(NAME,
-                VehicleSpeed.create(NAME, 4, 2.0, false),
-                VehiclePriority.create(NAME, 4, PriorityCode.getFactor(1), false)
+                /*
+                 * Defines an encoding for speed limits. It uses just 4 bits to store the actual speed limit defined on an edge.
+                 * It divides the actual speed limit by 2 before encoding it, reducing accuracy, but increasing the maximum storable
+                 * speed limit. Therefore, the maximum speed limit to be stored is 30 km/h. (2^4-1 = 15 * 2 = 30)
+                 * These are the default values used by GraphHopper, e.g., see DefaultImportRegistry.
+                 */
+                VehicleSpeed.create(NAME, 4, 2.0, false)
         );
     }
 

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/BikeProfile.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/BikeProfile.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.routing.graphhopper.profile;
+
+import com.google.common.collect.Lists;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.ev.VehiclePriority;
+import com.graphhopper.routing.ev.VehicleSpeed;
+import com.graphhopper.routing.util.PriorityCode;
+import com.graphhopper.routing.util.parsers.BikeAccessParser;
+import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.TagParser;
+import com.graphhopper.util.PMap;
+
+import java.util.List;
+
+public class BikeProfile extends RoutingProfile {
+
+    public final static String NAME = "bike";
+
+    public BikeProfile() {
+        super(NAME,
+                VehicleSpeed.create(NAME, 4, 2.0, false),
+                VehiclePriority.create(NAME, 4, PriorityCode.getFactor(1), false)
+        );
+    }
+
+    @Override
+    public List<TagParser> createTagParsers(EncodedValueLookup lookup) {
+        return Lists.newArrayList(
+                new BikeAccessParser(lookup, new PMap()),
+                new BikeAverageSpeedParser(lookup)
+        );
+    }
+}

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/CarProfile.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/CarProfile.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.routing.graphhopper.profile;
+
+import com.google.common.collect.Lists;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.ev.VehicleSpeed;
+import com.graphhopper.routing.util.parsers.CarAccessParser;
+import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.TagParser;
+import com.graphhopper.util.PMap;
+
+import java.util.List;
+
+public class CarProfile extends RoutingProfile {
+
+    public final static String NAME = "car";
+
+    public CarProfile() {
+        super(NAME,
+                VehicleSpeed.create(NAME, 7, 2.0, true),
+                null
+        );
+    }
+
+    @Override
+    public List<TagParser> createTagParsers(EncodedValueLookup lookup) {
+        return Lists.newArrayList(
+                new CarAccessParser(lookup, new PMap()),
+                new CarAverageSpeedParser(lookup)
+        );
+    }
+}

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/CarProfile.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/CarProfile.java
@@ -31,8 +31,14 @@ public class CarProfile extends RoutingProfile {
 
     public CarProfile() {
         super(NAME,
-                VehicleSpeed.create(NAME, 7, 2.0, true),
-                null
+                /*
+                 * Defines an encoding for speed limits. It uses 7 bits to store the actual speed limit defined on an edge.
+                 * It divides the actual speed limit by 2 before encoding it, reducing accuracy, but increasing the maximum storable
+                 * speed limit. Therefore, the maximum speed limit to be stored is 254 km/h. (2^7-1 = 127 * 2 = 254).
+                 * It can store different speed limits for each direction, doubling the required number of bits per edge.
+                 * These are the default values used by GraphHopper, e.g., see DefaultImportRegistry.
+                 */
+                VehicleSpeed.create(NAME, 7, 2.0, true)
         );
     }
 

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/RoutingProfile.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/RoutingProfile.java
@@ -23,24 +23,40 @@ import com.graphhopper.routing.util.parsers.TagParser;
 
 import java.util.List;
 
+/**
+ * Provides quick access to parsers and the specific {@link VehicleEncoding} instance
+ * related to a specific vehicle profile (e.g., bike or car)
+ *
+ * @see BikeProfile
+ * @see CarProfile
+ */
 public abstract class RoutingProfile {
 
     private final VehicleEncoding vehicleEncoding;
     private final String name;
 
-    protected RoutingProfile(String name, DecimalEncodedValue speedEncoding, DecimalEncodedValue priorityEncoding) {
+    protected RoutingProfile(String name, DecimalEncodedValue speedEncoding) {
         this.name = name;
-        this.vehicleEncoding = new VehicleEncoding(name, speedEncoding, priorityEncoding);
+        this.vehicleEncoding = new VehicleEncoding(name, speedEncoding);
     }
 
+    /**
+     * The name of the {@link RoutingProfile}.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Access to the {@link com.graphhopper.routing.ev.EncodedValue} instances used specifically by this {@link RoutingProfile}.
+     */
     public VehicleEncoding getVehicleEncoding() {
         return vehicleEncoding;
     }
 
+    /**
+     * A list of parsers used to fill {@link com.graphhopper.routing.ev.EncodedValue} instances from road data.
+     */
     public abstract List<TagParser> createTagParsers(EncodedValueLookup lookup);
 
 }

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/RoutingProfile.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/profile/RoutingProfile.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.routing.graphhopper.profile;
+
+import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncoding;
+
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.parsers.TagParser;
+
+import java.util.List;
+
+public abstract class RoutingProfile {
+
+    private final VehicleEncoding vehicleEncoding;
+    private final String name;
+
+    protected RoutingProfile(String name, DecimalEncodedValue speedEncoding, DecimalEncodedValue priorityEncoding) {
+        this.name = name;
+        this.vehicleEncoding = new VehicleEncoding(name, speedEncoding, priorityEncoding);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public VehicleEncoding getVehicleEncoding() {
+        return vehicleEncoding;
+    }
+
+    public abstract List<TagParser> createTagParsers(EncodedValueLookup lookup);
+
+}

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/RoutingProfileManager.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/RoutingProfileManager.java
@@ -35,7 +35,10 @@ import java.util.function.Supplier;
  * In GraphHopper, any data for edges, nodes, and turns, are stored with as low overhead
  * as possible. To achieve this, {@link com.graphhopper.routing.ev.EncodedValue}s
  * to encode and decode any data. This class, encapsulates the initialization and access to single
- * {@link com.graphhopper.routing.ev.EncodedValue}s, making it easier to use them in code.
+ * {@link com.graphhopper.routing.ev.EncodedValue}s, making it easier to use them in code. Each
+ * vehicle has a different set of {@link com.graphhopper.routing.ev.EncodedValue} instances, thus
+ * they are bundled in each {@link RoutingProfile} which this class manages. It also provides
+ * access to the {@link EncodingManager} in general, which GraphHopper needs at several places.
  */
 public class RoutingProfileManager {
 
@@ -63,19 +66,20 @@ public class RoutingProfileManager {
                     .addTurnCostEncodedValue(encoding.turnRestriction())
                     .addTurnCostEncodedValue(encoding.turnCost())
                     .add(encoding.subnetwork());
-            if (encoding.priority() != null) {
-                builder.add(encoding.priority());
-            }
         }
         this.encodingManager = builder.build();
     }
 
+    /**
+     * Returns all available {@link RoutingProfile}s.
+     */
     public Collection<RoutingProfile> getAllProfiles() {
         return Collections.unmodifiableCollection(routingProfiles.values());
     }
 
     /**
-     * Returns the specific wrapper of {@link com.graphhopper.routing.ev.EncodedValue}s required
+     * Returns the specific {@link RoutingProfile} wrapper of
+     * {@link com.graphhopper.routing.ev.EncodedValue}s required
      * for the given transportation mode (e.g. "car", "bike").
      */
     public RoutingProfile getRoutingProfile(String vehicle) {
@@ -83,7 +87,7 @@ public class RoutingProfileManager {
     }
 
     /**
-     * Returns the actual encoding manager used in GraphHopper.
+     * Returns the actual encoding manager used by GraphHopper.
      */
     public EncodingManager getEncodingManager() {
         return encodingManager;

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/VehicleEncoding.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/VehicleEncoding.java
@@ -15,19 +15,12 @@
 
 package org.eclipse.mosaic.lib.routing.graphhopper.util;
 
-import com.graphhopper.config.Profile;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.DefaultImportRegistry;
-import com.graphhopper.routing.ev.ImportRegistry;
-import com.graphhopper.routing.ev.ImportUnit;
 import com.graphhopper.routing.ev.Subnetwork;
 import com.graphhopper.routing.ev.TurnCost;
 import com.graphhopper.routing.ev.TurnRestriction;
 import com.graphhopper.routing.ev.VehicleAccess;
-import com.graphhopper.routing.ev.VehiclePriority;
-import com.graphhopper.routing.ev.VehicleSpeed;
-import com.graphhopper.util.PMap;
 
 /**
  * Collection of all {@link com.graphhopper.routing.ev.EncodedValue} implementations
@@ -48,18 +41,13 @@ public class VehicleEncoding {
     private final DecimalEncodedValue priorityEnc;
     private final BooleanEncodedValue subnetworkEnc;
 
-    VehicleEncoding(Profile profile) {
-        final ImportRegistry registry = new DefaultImportRegistry();
-
-        this.accessEnc = (BooleanEncodedValue) registry.createImportUnit(VehicleAccess.key(profile.getName())).getCreateEncodedValue().apply(new PMap());
-        this.speedEnc = (DecimalEncodedValue) registry.createImportUnit(VehicleSpeed.key(profile.getName())).getCreateEncodedValue().apply(new PMap());
-
-        ImportUnit priorityImportUnit = registry.createImportUnit(VehiclePriority.key(profile.getName()));
-        this.priorityEnc = priorityImportUnit != null ? (DecimalEncodedValue) priorityImportUnit.getCreateEncodedValue().apply(new PMap()) : null;
-
-        this.turnRestrictionEnc = TurnRestriction.create(profile.getName());
-        this.turnCostEnc = TurnCost.create(profile.getName(), 255);
-        this.subnetworkEnc = Subnetwork.create(profile.getName());
+    public VehicleEncoding(String vehicleName, DecimalEncodedValue speedEnc, DecimalEncodedValue priorityEnc) {
+        this.speedEnc = speedEnc;
+        this.priorityEnc = priorityEnc;
+        this.accessEnc = VehicleAccess.create(vehicleName);
+        this.turnRestrictionEnc = TurnRestriction.create(vehicleName);
+        this.turnCostEnc = TurnCost.create(vehicleName, 255);
+        this.subnetworkEnc = Subnetwork.create(vehicleName);
     }
 
     public BooleanEncodedValue access() {

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/VehicleEncoding.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/VehicleEncoding.java
@@ -38,12 +38,10 @@ public class VehicleEncoding {
     private final DecimalEncodedValue speedEnc;
     private final BooleanEncodedValue turnRestrictionEnc;
     private final DecimalEncodedValue turnCostEnc;
-    private final DecimalEncodedValue priorityEnc;
     private final BooleanEncodedValue subnetworkEnc;
 
-    public VehicleEncoding(String vehicleName, DecimalEncodedValue speedEnc, DecimalEncodedValue priorityEnc) {
+    public VehicleEncoding(String vehicleName, DecimalEncodedValue speedEnc) {
         this.speedEnc = speedEnc;
-        this.priorityEnc = priorityEnc;
         this.accessEnc = VehicleAccess.create(vehicleName);
         this.turnRestrictionEnc = TurnRestriction.create(vehicleName);
         this.turnCostEnc = TurnCost.create(vehicleName, 255);
@@ -56,10 +54,6 @@ public class VehicleEncoding {
 
     public DecimalEncodedValue speed() {
         return speedEnc;
-    }
-
-    public DecimalEncodedValue priority() {
-        return priorityEnc;
     }
 
     public BooleanEncodedValue turnRestriction() {

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/VehicleEncodingManager.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/util/VehicleEncodingManager.java
@@ -16,6 +16,12 @@
 package org.eclipse.mosaic.lib.routing.graphhopper.util;
 
 import com.graphhopper.config.Profile;
+import com.graphhopper.routing.ev.FerrySpeed;
+import com.graphhopper.routing.ev.MaxSpeed;
+import com.graphhopper.routing.ev.RoadClass;
+import com.graphhopper.routing.ev.RoadClassLink;
+import com.graphhopper.routing.ev.Roundabout;
+import com.graphhopper.routing.ev.Smoothness;
 import com.graphhopper.routing.util.EncodingManager;
 
 import java.util.ArrayList;
@@ -43,10 +49,17 @@ public class VehicleEncodingManager {
         this.waytypeEncoder = WayTypeEncoder.create();
         this.profiles = new ArrayList<>(profiles);
 
-        EncodingManager.Builder builder = new EncodingManager.Builder().add(waytypeEncoder);
+        EncodingManager.Builder builder = new EncodingManager.Builder()
+                .add(waytypeEncoder)
+                .add(Roundabout.create())
+                .add(RoadClass.create())
+                .add(RoadClassLink.create())
+                .add(FerrySpeed.create())
+                .add(Smoothness.create())
+                .add(MaxSpeed.create());
         for (Profile profile : this.profiles) {
             final VehicleEncoding encoding = new VehicleEncoding(profile);
-            vehicleEncodings.put(profile.getVehicle(), encoding);
+            vehicleEncodings.put(profile.getName(), encoding);
             builder.add(encoding.access())
                     .add(encoding.speed())
                     .addTurnCostEncodedValue(encoding.turnRestriction())

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/pt/PtRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/pt/PtRouting.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.mosaic.lib.routing.pt;
 
+import static com.graphhopper.json.Statement.If;
+
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.math.SpeedUtils;
 import org.eclipse.mosaic.lib.objects.pt.PtStop;
@@ -33,6 +35,8 @@ import com.graphhopper.gtfs.GraphHopperGtfs;
 import com.graphhopper.gtfs.PtRouter;
 import com.graphhopper.gtfs.PtRouterImpl;
 import com.graphhopper.gtfs.Request;
+import com.graphhopper.json.Statement;
+import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.StopWatch;
 import com.graphhopper.util.TranslationMap;
 import org.apache.commons.lang3.Validate;
@@ -96,7 +100,11 @@ public class PtRouting {
                 .putObject("graph.location", baseDirectory.resolve("ptgraph").toAbsolutePath().toString()) //
                 .putObject("datareader.file", baseDirectory.resolve(routingConfiguration.osmFile).toAbsolutePath().toString())
                 .putObject("gtfs.file", baseDirectory.resolve(routingConfiguration.gtfsFile).toAbsolutePath().toString())
-                .setProfiles(Collections.singletonList(new Profile("foot").setVehicle("foot")));
+                .putObject("graph.encoded_values", "foot_access, foot_priority, foot_average_speed")
+                .setProfiles(Collections.singletonList(new Profile("foot").setCustomModel(new CustomModel()
+                                .addToPriority(If("!foot_access", Statement.Op.MULTIPLY, "0"))
+                                .addToSpeed(If("true", Statement.Op.LIMIT, "foot_average_speed"))))
+                );
 
         final StopWatch sw = new StopWatch();
         sw.start();

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperWeightingTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperWeightingTest.java
@@ -21,10 +21,12 @@ import org.eclipse.mosaic.lib.routing.RoutingCostFunction;
 import org.eclipse.mosaic.lib.routing.graphhopper.junit.TestGraphRule;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.OptionalTurnCostProvider;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncoding;
+import org.eclipse.mosaic.lib.routing.graphhopper.util.WayTypeEncoder;
 
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -33,11 +35,18 @@ public class GraphHopperWeightingTest {
     @Rule
     public TestGraphRule testGraph = new TestGraphRule();
 
+    private VehicleEncoding vehicleEnc;
+    private WayTypeEncoder wayTypeEnc;
+
+    @Before
+    public void setup() {
+        vehicleEnc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
+        wayTypeEnc = testGraph.getProfileManager().getEncodingManager().getEncodedValue(WayTypeEncoder.KEY, WayTypeEncoder.class);
+    }
+
     @Test
     public void fastest_noTurnCosts() {
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-
-        Weighting w = new GraphHopperWeighting(enc, testGraph.getEncodingManager().wayType(), new OptionalTurnCostProvider(enc, testGraph.getGraph().getTurnCostStorage()), null)
+        Weighting w = new GraphHopperWeighting(vehicleEnc, wayTypeEnc, new OptionalTurnCostProvider(vehicleEnc, testGraph.getGraph().getTurnCostStorage()), null)
                 .setRoutingCostFunction(RoutingCostFunction.Fastest);
 
         EdgeExplorer expl = testGraph.getGraph().createEdgeExplorer();
@@ -48,15 +57,13 @@ public class GraphHopperWeightingTest {
         double weight = w.calcEdgeWeight(it, false);
         double turnWeight = w.calcTurnWeight(1, 0, 0);
 
-        assertEquals(distance / enc.speed().getMaxOrMaxStorableDecimal() * 3.6, weight, 0.1d);
+        assertEquals(distance / vehicleEnc.speed().getMaxOrMaxStorableDecimal() * 3.6, weight, 0.1d);
         assertEquals(0, turnWeight, 0.1d);
     }
 
     @Test
     public void shortest_noTurnCosts() {
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-
-        Weighting w = new GraphHopperWeighting(enc, testGraph.getEncodingManager().wayType(), new OptionalTurnCostProvider(enc, testGraph.getGraph().getTurnCostStorage()), null)
+        Weighting w = new GraphHopperWeighting(vehicleEnc, wayTypeEnc, new OptionalTurnCostProvider(vehicleEnc, testGraph.getGraph().getTurnCostStorage()), null)
                 .setRoutingCostFunction(RoutingCostFunction.Shortest);
 
         EdgeExplorer expl = testGraph.getGraph().createEdgeExplorer();
@@ -74,11 +81,9 @@ public class GraphHopperWeightingTest {
 
     @Test
     public void shortest_turnCosts() {
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        testGraph.getGraph().getTurnCostStorage().set(vehicleEnc.turnCost(), 1, 0, 0, 10.0);
 
-        testGraph.getGraph().getTurnCostStorage().set(enc.turnCost(), 1, 0, 0, 10.0);
-
-        Weighting w = new GraphHopperWeighting(enc, testGraph.getEncodingManager().wayType(), new OptionalTurnCostProvider(enc, testGraph.getGraph().getTurnCostStorage()), null)
+        Weighting w = new GraphHopperWeighting(vehicleEnc, wayTypeEnc, new OptionalTurnCostProvider(vehicleEnc, testGraph.getGraph().getTurnCostStorage()), null)
                 .setRoutingCostFunction(RoutingCostFunction.Shortest);
 
         EdgeExplorer expl = testGraph.getGraph().createEdgeExplorer();
@@ -95,11 +100,9 @@ public class GraphHopperWeightingTest {
 
     @Test
     public void fastest_turnCosts() {
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        testGraph.getGraph().getTurnCostStorage().set(vehicleEnc.turnCost(), 1, 0, 0, 10.0);
 
-        testGraph.getGraph().getTurnCostStorage().set(enc.turnCost(), 1, 0, 0, 10.0);
-
-        Weighting w = new GraphHopperWeighting(enc, testGraph.getEncodingManager().wayType(), new OptionalTurnCostProvider(enc, testGraph.getGraph().getTurnCostStorage()), null)
+        Weighting w = new GraphHopperWeighting(vehicleEnc, wayTypeEnc, new OptionalTurnCostProvider(vehicleEnc, testGraph.getGraph().getTurnCostStorage()), null)
                 .setRoutingCostFunction(RoutingCostFunction.Fastest);
 
         EdgeExplorer expl = testGraph.getGraph().createEdgeExplorer();
@@ -110,17 +113,15 @@ public class GraphHopperWeightingTest {
         double weight = w.calcEdgeWeight(it, false);
         double turnWeight = w.calcTurnWeight(1, 0, 0);
 
-        assertEquals(distance / enc.speed().getMaxOrMaxStorableDecimal() * 3.6, weight, 0.1d);
+        assertEquals(distance / vehicleEnc.speed().getMaxOrMaxStorableDecimal() * 3.6, weight, 0.1d);
         assertEquals(10, turnWeight, 0.1d);
     }
 
     @Test
     public void shortest_turnRestriction() {
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        testGraph.getGraph().getTurnCostStorage().set(vehicleEnc.turnRestriction(), 1, 0, 0, true);
 
-        testGraph.getGraph().getTurnCostStorage().set(enc.turnRestriction(), 1, 0, 0, true);
-
-        Weighting w = new GraphHopperWeighting(enc, testGraph.getEncodingManager().wayType(), new OptionalTurnCostProvider(enc, testGraph.getGraph().getTurnCostStorage()), null)
+        Weighting w = new GraphHopperWeighting(vehicleEnc, wayTypeEnc, new OptionalTurnCostProvider(vehicleEnc, testGraph.getGraph().getTurnCostStorage()), null)
                 .setRoutingCostFunction(RoutingCostFunction.Shortest);
 
         EdgeExplorer expl = testGraph.getGraph().createEdgeExplorer();
@@ -137,11 +138,9 @@ public class GraphHopperWeightingTest {
 
     @Test
     public void fastest_turnRestriction() {
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        testGraph.getGraph().getTurnCostStorage().set(vehicleEnc.turnRestriction(), 1, 0, 0, true);
 
-        testGraph.getGraph().getTurnCostStorage().set(enc.turnRestriction(), 1, 0, 0, true);
-
-        Weighting w = new GraphHopperWeighting(enc, testGraph.getEncodingManager().wayType(), new OptionalTurnCostProvider(enc, testGraph.getGraph().getTurnCostStorage()), null)
+        Weighting w = new GraphHopperWeighting(vehicleEnc, wayTypeEnc, new OptionalTurnCostProvider(vehicleEnc, testGraph.getGraph().getTurnCostStorage()), null)
                 .setRoutingCostFunction(RoutingCostFunction.Fastest);
 
         EdgeExplorer expl = testGraph.getGraph().createEdgeExplorer();
@@ -152,7 +151,7 @@ public class GraphHopperWeightingTest {
         double weight = w.calcEdgeWeight(it, false);
         double turnWeight = w.calcTurnWeight(1, 0, 0);
 
-        assertEquals(distance / enc.speed().getMaxOrMaxStorableDecimal() * 3.6, weight, 0.1d);
+        assertEquals(distance / vehicleEnc.speed().getMaxOrMaxStorableDecimal() * 3.6, weight, 0.1d);
         assertEquals(Double.POSITIVE_INFINITY, turnWeight, 0.1d);
     }
 

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperWeightingTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperWeightingTest.java
@@ -48,7 +48,7 @@ public class GraphHopperWeightingTest {
         double weight = w.calcEdgeWeight(it, false);
         double turnWeight = w.calcTurnWeight(1, 0, 0);
 
-        assertEquals(distance / enc.speed().getMaxStorableDecimal() * 3.6, weight, 0.1d);
+        assertEquals(distance / enc.speed().getMaxOrMaxStorableDecimal() * 3.6, weight, 0.1d);
         assertEquals(0, turnWeight, 0.1d);
     }
 

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/AlternativeRoutesRoutingTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/AlternativeRoutesRoutingTest.java
@@ -45,7 +45,7 @@ public class AlternativeRoutesRoutingTest {
     @Test
     public void calculateAlternativePaths_withTurnCost() {
         BaseGraph g = testGraph.getGraph();
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        VehicleEncoding enc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
         Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null);
 
         //100 seconds turn costs for turn  (0-1)->(1-2)
@@ -81,7 +81,7 @@ public class AlternativeRoutesRoutingTest {
     @Test
     public void calculateAlternativePaths() {
         BaseGraph g = testGraph.getGraph();
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        VehicleEncoding enc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
         Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null);
 
         RoutingAlgorithm algo = RoutingAlgorithmFactory.DEFAULT.createAlgorithm(g, w,
@@ -113,7 +113,7 @@ public class AlternativeRoutesRoutingTest {
     @Test
     public void calculateBestPath() {
         BaseGraph g = testGraph.getGraph();
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        VehicleEncoding enc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
         Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null);
 
         RoutingAlgorithm algo = RoutingAlgorithmFactory.DEFAULT.createAlgorithm(g, w, new PMap());

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/AlternativeRoutesRoutingTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/AlternativeRoutesRoutingTest.java
@@ -17,6 +17,7 @@ package org.eclipse.mosaic.lib.routing.graphhopper.algorithm;
 
 import static org.junit.Assert.assertEquals;
 
+import org.eclipse.mosaic.lib.routing.graphhopper.GraphHopperWeighting;
 import org.eclipse.mosaic.lib.routing.graphhopper.junit.TestGraphRule;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.GHListHelper;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.OptionalTurnCostProvider;
@@ -24,7 +25,6 @@ import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncoding;
 
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.RoutingAlgorithm;
-import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.util.PMap;
@@ -46,7 +46,7 @@ public class AlternativeRoutesRoutingTest {
     public void calculateAlternativePaths_withTurnCost() {
         BaseGraph g = testGraph.getGraph();
         VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-        Weighting w = new FastestWeighting(enc.access(), enc.speed(), new OptionalTurnCostProvider(enc, g.getTurnCostStorage()));
+        Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null);
 
         //100 seconds turn costs for turn  (0-1)->(1-2)
         g.getTurnCostStorage().set(enc.turnCost(), 0, 1, 2, 100);
@@ -82,7 +82,7 @@ public class AlternativeRoutesRoutingTest {
     public void calculateAlternativePaths() {
         BaseGraph g = testGraph.getGraph();
         VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-        Weighting w = new FastestWeighting(enc.access(), enc.speed(), new OptionalTurnCostProvider(enc, g.getTurnCostStorage()));
+        Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null);
 
         RoutingAlgorithm algo = RoutingAlgorithmFactory.DEFAULT.createAlgorithm(g, w,
                 new PMap().putObject(Parameters.Algorithms.AltRoute.MAX_PATHS, 3)
@@ -114,7 +114,7 @@ public class AlternativeRoutesRoutingTest {
     public void calculateBestPath() {
         BaseGraph g = testGraph.getGraph();
         VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-        Weighting w = new FastestWeighting(enc.access(), enc.speed(), new OptionalTurnCostProvider(enc, g.getTurnCostStorage()));
+        Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null);
 
         RoutingAlgorithm algo = RoutingAlgorithmFactory.DEFAULT.createAlgorithm(g, w, new PMap());
 

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/BellmanFordRoutingTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/BellmanFordRoutingTest.java
@@ -41,7 +41,7 @@ public class BellmanFordRoutingTest {
     @Test
     public void calculateFastestPath() {
         BaseGraph g = testGraph.getGraph();
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        VehicleEncoding enc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
         Weighting w = new GraphHopperWeighting(enc, null, TurnCostProvider.NO_TURN_COST_PROVIDER, null)
                 .setRoutingCostFunction(RoutingCostFunction.Fastest);
 
@@ -56,7 +56,7 @@ public class BellmanFordRoutingTest {
     @Test
     public void calculateFastestPath_turnCosts() {
         BaseGraph g = testGraph.getGraph();
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        VehicleEncoding enc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
         Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null)
                 .setRoutingCostFunction(RoutingCostFunction.Fastest);
 
@@ -74,7 +74,7 @@ public class BellmanFordRoutingTest {
     @Test
     public void calculateShortestPath() {
         BaseGraph g = testGraph.getGraph();
-        VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
+        VehicleEncoding enc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
         Weighting w = new GraphHopperWeighting(enc, null, TurnCostProvider.NO_TURN_COST_PROVIDER, null)
                 .setRoutingCostFunction(RoutingCostFunction.Shortest);
 

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/BellmanFordRoutingTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/algorithm/BellmanFordRoutingTest.java
@@ -17,14 +17,15 @@ package org.eclipse.mosaic.lib.routing.graphhopper.algorithm;
 
 import static org.junit.Assert.assertEquals;
 
+import org.eclipse.mosaic.lib.routing.RoutingCostFunction;
+import org.eclipse.mosaic.lib.routing.graphhopper.GraphHopperWeighting;
 import org.eclipse.mosaic.lib.routing.graphhopper.junit.TestGraphRule;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.GHListHelper;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.OptionalTurnCostProvider;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncoding;
 
 import com.graphhopper.routing.Path;
-import com.graphhopper.routing.weighting.FastestWeighting;
-import com.graphhopper.routing.weighting.ShortestWeighting;
+import com.graphhopper.routing.weighting.TurnCostProvider;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.util.PMap;
@@ -41,7 +42,8 @@ public class BellmanFordRoutingTest {
     public void calculateFastestPath() {
         BaseGraph g = testGraph.getGraph();
         VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-        Weighting w = new FastestWeighting(enc.access(), enc.speed());
+        Weighting w = new GraphHopperWeighting(enc, null, TurnCostProvider.NO_TURN_COST_PROVIDER, null)
+                .setRoutingCostFunction(RoutingCostFunction.Fastest);
 
         //run
         Path p = new BellmanFordRouting(g, w, new PMap()).calcPath(0, 10);
@@ -55,7 +57,8 @@ public class BellmanFordRoutingTest {
     public void calculateFastestPath_turnCosts() {
         BaseGraph g = testGraph.getGraph();
         VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-        Weighting w = new FastestWeighting(enc.access(), enc.speed(), new OptionalTurnCostProvider(enc, g.getTurnCostStorage()));
+        Weighting w = new GraphHopperWeighting(enc, null, new OptionalTurnCostProvider(enc, g.getTurnCostStorage()), null)
+                .setRoutingCostFunction(RoutingCostFunction.Fastest);
 
         //add expensive turn at (0-1)->(1,5)
         g.getTurnCostStorage().set(enc.turnCost(), 0, 1, 3, 124);
@@ -72,7 +75,8 @@ public class BellmanFordRoutingTest {
     public void calculateShortestPath() {
         BaseGraph g = testGraph.getGraph();
         VehicleEncoding enc = testGraph.getEncodingManager().getVehicleEncoding("car");
-        Weighting w = new ShortestWeighting(enc.access(), enc.speed());
+        Weighting w = new GraphHopperWeighting(enc, null, TurnCostProvider.NO_TURN_COST_PROVIDER, null)
+                .setRoutingCostFunction(RoutingCostFunction.Shortest);
 
         //run
         Path p = new BellmanFordRouting(g, w, new PMap()).calcPath(0, 10);

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/junit/TestGraphRule.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/junit/TestGraphRule.java
@@ -16,8 +16,8 @@
 package org.eclipse.mosaic.lib.routing.graphhopper.junit;
 
 import org.eclipse.mosaic.lib.routing.graphhopper.GraphHopperRouting;
+import org.eclipse.mosaic.lib.routing.graphhopper.util.RoutingProfileManager;
 import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncoding;
-import org.eclipse.mosaic.lib.routing.graphhopper.util.VehicleEncodingManager;
 
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.storage.BaseGraph;
@@ -26,7 +26,7 @@ import org.junit.rules.ExternalResource;
 public class TestGraphRule extends ExternalResource {
 
     private BaseGraph graph;
-    private final VehicleEncodingManager encodingManager;
+    private final RoutingProfileManager profileManager;
 
     private final boolean emptyGraph;
 
@@ -35,18 +35,18 @@ public class TestGraphRule extends ExternalResource {
     }
 
     public TestGraphRule(boolean emptyGraph) {
-        this.encodingManager = new VehicleEncodingManager(GraphHopperRouting.PROFILES);
+        this.profileManager = new RoutingProfileManager(GraphHopperRouting.PROFILES);
         this.emptyGraph = emptyGraph;
     }
 
-    public VehicleEncodingManager getEncodingManager() {
-        return encodingManager;
+    public RoutingProfileManager getProfileManager() {
+        return profileManager;
     }
 
     @Override
     protected void before() throws Throwable {
 
-        graph = new BaseGraph.Builder(encodingManager.getEncodingManager())
+        graph = new BaseGraph.Builder(profileManager.getEncodingManager())
                 .withTurnCosts(true)
                 .build();
 
@@ -108,7 +108,7 @@ public class TestGraphRule extends ExternalResource {
         graph.edge(12, 13).setDistance(1000); //21
 
 
-        VehicleEncoding enc = encodingManager.getVehicleEncoding("car");
+        VehicleEncoding enc = profileManager.getRoutingProfile("car").getVehicleEncoding();
         AllEdgesIterator it = graph.getAllEdges();
         while (it.next()) {
             it.set(enc.access(), true);

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/util/DatabaseGraphLoaderTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/util/DatabaseGraphLoaderTest.java
@@ -78,7 +78,7 @@ public class DatabaseGraphLoaderTest {
         assertEquals("#routes", 1, database.getRoutes().size());
 
         //run
-        reader.initialize(g, testGraph.getEncodingManager(), mapper);
+        reader.initialize(g, testGraph.getProfileManager(), mapper);
         reader.loadGraph();
 
         //assert
@@ -93,8 +93,8 @@ public class DatabaseGraphLoaderTest {
         int con3_2_3 = mapper.fromConnection(database.getConnection("3_2_3"));
         int con3_3_2 = mapper.fromConnection(database.getConnection("3_3_2"));
 
-        VehicleEncoding vehicleEncoding = testGraph.getEncodingManager().getVehicleEncoding("car");
-        WayTypeEncoder wayTypeEnc = testGraph.getEncodingManager().wayType();
+        VehicleEncoding vehicleEncoding = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding();
+        WayTypeEncoder wayTypeEnc = testGraph.getProfileManager().getEncodingManager().getEncodedValue(WayTypeEncoder.KEY, WayTypeEncoder.class);
 
         EdgeFilter outFilter = AccessFilter.outEdges(vehicleEncoding.access());
 

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/util/TurnCostAnalyzerTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/graphhopper/util/TurnCostAnalyzerTest.java
@@ -33,8 +33,11 @@ public class TurnCostAnalyzerTest {
     @Test
     public void turnCostsCalculation() {
         //run
-        new TurnCostAnalyzer(testGraph.getGraph(), testGraph.getEncodingManager().wayType())
-                .createTurnCostsForVehicle(testGraph.getEncodingManager().getVehicleEncoding("car"));
+        RoutingProfileManager profileManager = testGraph.getProfileManager();
+        WayTypeEncoder wayTypeEncoder = profileManager.getEncodingManager().getEncodedValue(WayTypeEncoder.KEY, WayTypeEncoder.class);
+
+        new TurnCostAnalyzer(testGraph.getGraph(), wayTypeEncoder)
+                .createTurnCostsForVehicle(profileManager.getRoutingProfile("car").getVehicleEncoding());
 
         //assert
         assertEquals(4d, getTurnCosts(1, 0, 0), 0.4d); //4 seconds for 90deg right turn
@@ -49,8 +52,8 @@ public class TurnCostAnalyzerTest {
 
     private double getTurnCosts(int fromEdge, int viaNode, int toEdge) {
         TurnCostStorage tc = testGraph.getGraph().getTurnCostStorage();
-        BooleanEncodedValue turnRestrictionsEnc = testGraph.getEncodingManager().getVehicleEncoding("car").turnRestriction();
-        DecimalEncodedValue turnCostsEnc = testGraph.getEncodingManager().getVehicleEncoding("car").turnCost();
+        BooleanEncodedValue turnRestrictionsEnc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding().turnRestriction();
+        DecimalEncodedValue turnCostsEnc = testGraph.getProfileManager().getRoutingProfile("car").getVehicleEncoding().turnCost();
 
         boolean isRestricted = tc.get(turnRestrictionsEnc, fromEdge, viaNode, toEdge);
         if (isRestricted) {

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <version.commons-math3>3.6.1</version.commons-math3><!-- 3.6.1 is approved in CQ22025 -->
         <version.commons-text>1.6</version.commons-text><!-- 1.6 is approved in CQ19028 -->
         <version.findbugs-annotations>1.3.9-1</version.findbugs-annotations><!-- 1.3.9-1 is approved in CQ15081 -->
-        <version.graphhopper>10.2</version.graphhopper><!-- 8.0 approved in #11407 and #11408 -->
+        <version.graphhopper>10.2</version.graphhopper><!-- 10.2 approved in #21152, #21153 and #21154  -->
         <version.gson>2.10.1</version.gson><!-- 2.10.1 is approved in #6159 -->
         <version.gtfs-bindings>0.0.5</version.gtfs-bindings><!-- 0.0.5 is approved in #1758 -->
         <version.guava>32.1.1-jre</version.guava><!-- 28.2-jre is approved in #9229 -->

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <version.commons-math3>3.6.1</version.commons-math3><!-- 3.6.1 is approved in CQ22025 -->
         <version.commons-text>1.6</version.commons-text><!-- 1.6 is approved in CQ19028 -->
         <version.findbugs-annotations>1.3.9-1</version.findbugs-annotations><!-- 1.3.9-1 is approved in CQ15081 -->
-        <version.graphhopper>8.0</version.graphhopper><!-- 8.0 approved in #11407 and #11408 -->
+        <version.graphhopper>10.2</version.graphhopper><!-- 8.0 approved in #11407 and #11408 -->
         <version.gson>2.10.1</version.gson><!-- 2.10.1 is approved in #6159 -->
         <version.gtfs-bindings>0.0.5</version.gtfs-bindings><!-- 0.0.5 is approved in #1758 -->
         <version.guava>32.1.1-jre</version.guava><!-- 28.2-jre is approved in #9229 -->


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

Upgrade graphhopper depedencie from 8.0 to 10.2

* The way how default parsers and encodings were provided changed completely, and is actually more complicate then before. Therefore, we now skip these default factories (now called `DefaultImportRegistry` in Graphhopper) and set the default encodings and parsers depending on the cars and bicycles by our own. 
* This comes with a light refactoring, which introduces the `RoutingProfileManager` and two pre-defined `RoutingProfiles` (`CarRoutingProfile` and `BikeRoutingProfile`) 

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 1047
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

