### PR TITLE
clean(objects): Renamed id field in TrafficLight object to index

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/TrafficLightIndex.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/TrafficLightIndex.java
@@ -43,7 +43,7 @@ public class TrafficLightIndex {
 
     private KdTree<TrafficLightObject> trafficLightTree;
 
-    private SpatialTreeTraverser.InRadius<TrafficLightObject> treeTraverser;
+    private final SpatialTreeTraverser.InRadius<TrafficLightObject> treeTraverser;
 
     private boolean triggerNewTree = false;
 
@@ -86,7 +86,7 @@ public class TrafficLightIndex {
         String trafficLightGroupId = trafficLightGroup.getGroupId();
         trafficLightGroup.getTrafficLights().forEach(
                 (trafficLight) -> {
-                    String trafficLightId = calculateTrafficLightId(trafficLightGroupId, trafficLight.getId());
+                    String trafficLightId = calculateTrafficLightId(trafficLightGroupId, trafficLight.getIndex());
                     if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds()
                             .contains(trafficLight.getPosition().toCartesian())) { // check if inside bounding area
                         indexedTrafficLights.computeIfAbsent(trafficLightId, TrafficLightObject::new)
@@ -120,6 +120,9 @@ public class TrafficLightIndex {
         );
     }
 
+    /**
+     * This is used as a "hack" to get a unique id for each traffic light signal, by combining the group id with the index
+     */
     private String calculateTrafficLightId(String trafficLightGroupId, int trafficLightIndex) {
         return trafficLightGroupId + "_" + trafficLightIndex;
     }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/TrafficLightIndex.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/TrafficLightIndex.java
@@ -121,7 +121,7 @@ public class TrafficLightIndex {
     }
 
     /**
-     * This is used as a "hack" to get a unique id for each traffic light signal, by combining the group id with the index
+     * This is used as a workaround to get a unique id for each traffic light signal, by combining the group id with the index
      */
     private String calculateTrafficLightId(String trafficLightGroupId, int trafficLightIndex) {
         return trafficLightGroupId + "_" + trafficLightIndex;

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -62,7 +62,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RunWith(Parameterized.class)
 public class SimplePerceptionModuleTest {
@@ -108,17 +107,11 @@ public class SimplePerceptionModuleTest {
                 .thenReturn(new CartesianRectangle(new MutableCartesianPoint(100, 90, 0), new MutableCartesianPoint(310, 115, 0)));
         SimulationKernel.SimulationKernel.setConfiguration(new CApplicationAmbassador());
 
-        VehicleIndex vehicleIndex;
-        switch (vehicleIndexType) {
-            case "tree":
-                vehicleIndex = new VehicleTree(20, 12);
-                break;
-            case "grid":
-                vehicleIndex = new VehicleGrid(5, 5);
-                break;
-            default:
-                vehicleIndex = null;
-        }
+        VehicleIndex vehicleIndex = switch (vehicleIndexType) {
+            case "tree" -> new VehicleTree(20, 12);
+            case "grid" -> new VehicleGrid(5, 5);
+            default -> null;
+        };
 
         trafficObjectIndex = new TrafficObjectIndex.Builder(mock((Logger.class)))
                 .withVehicleIndex(vehicleIndex)
@@ -265,7 +258,7 @@ public class SimplePerceptionModuleTest {
             when(trafficLightMock.getCurrentState()).thenReturn(TrafficLightState.GREEN);
             when(trafficLightMock.getIncomingLane()).thenReturn("E0_0");
             when(trafficLightMock.getOutgoingLane()).thenReturn("E1_0");
-            when(trafficLightMock.getId()).thenReturn(i++);
+            when(trafficLightMock.getIndex()).thenReturn(i++);
             trafficLightMocks.add(trafficLightMock);
         }
         TrafficLightGroup trafficLightGroup = new TrafficLightGroup("tls", trafficLightProgramsMocks, trafficLightMocks);

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/TrafficLightIndexTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/TrafficLightIndexTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.mosaic.fed.application.ambassador.SimulationKernelRule;
-import org.eclipse.mosaic.fed.application.ambassador.simulation.navigation.CentralNavigationComponent;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.objects.TrafficLightObject;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers.TrafficLightIndex;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
@@ -35,14 +34,12 @@ import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroupInfo;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightProgram;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightState;
-import org.eclipse.mosaic.lib.util.scheduling.EventManager;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
@@ -77,7 +74,7 @@ public class TrafficLightIndexTest {
             when(trafficLightMock.getCurrentState()).thenReturn(TrafficLightState.GREEN);
             when(trafficLightMock.getIncomingLane()).thenReturn("E0_0");
             when(trafficLightMock.getOutgoingLane()).thenReturn("E1_0");
-            when(trafficLightMock.getId()).thenReturn((int) position.getZ()); // on purpose
+            when(trafficLightMock.getIndex()).thenReturn((int) position.getZ()); // on purpose
             trafficLightMocks.add(trafficLightMock);
         }
         TrafficLightGroup trafficLightGroup = new TrafficLightGroup("tls", trafficLightProgramsMocks, trafficLightMocks);

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLight.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLight.java
@@ -19,6 +19,8 @@ import org.eclipse.mosaic.lib.geo.GeoPoint;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -58,7 +60,7 @@ public class TrafficLight implements Serializable {
     /**
      * Constructor that initializes the main instance variables.
      *
-     * @param index           Signal id within the traffic light group
+     * @param index        Signal index within the traffic light group
      * @param position     geo position of the traffic light. Can also be position of the according junction when received from TraCI
      * @param incomingLane an incoming lane controlled by the traffic light
      * @param outgoingLane an outgoing lane controlled by the traffic light
@@ -140,13 +142,13 @@ public class TrafficLight implements Serializable {
 
     @Override
     public String toString() {
-        return "TrafficLightSignal{"
-                + "id=" + index
-                + ", currentState=" + currentState
-                + ", incomingLane=" + incomingLane
-                + ", outgoingLane=" + outgoingLane
-                + ", position=" + position
-                + '}';
+        return new ToStringBuilder(ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("index", index)
+                .append("currentState", currentState)
+                .append("incomingLane", incomingLane)
+                .append("outgoingLane", outgoingLane)
+                .append("position", position)
+                .build();
     }
 
 }

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLight.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLight.java
@@ -20,6 +20,7 @@ import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -27,12 +28,13 @@ import java.io.Serializable;
  */
 public class TrafficLight implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**
-     * Signal id (index) within the traffic light group.
+     * Signal index within the traffic light group, can be combined to a unique id with the traffic light group id.
      */
-    private final int id;
+    private final int index;
 
     /**
      * Geo position of a traffic light.
@@ -56,14 +58,14 @@ public class TrafficLight implements Serializable {
     /**
      * Constructor that initializes the main instance variables.
      *
-     * @param id           Signal id within the traffic light group
+     * @param index           Signal id within the traffic light group
      * @param position     geo position of the traffic light. Can also be position of the according junction when received from TraCI
      * @param incomingLane an incoming lane controlled by the traffic light
      * @param outgoingLane an outgoing lane controlled by the traffic light
      * @param initialState traffic light state
      */
-    public TrafficLight(int id, GeoPoint position, String incomingLane, String outgoingLane, TrafficLightState initialState) {
-        this.id = id;
+    public TrafficLight(int index, GeoPoint position, String incomingLane, String outgoingLane, TrafficLightState initialState) {
+        this.index = index;
         this.position = position;
         this.incomingLane = incomingLane;
         this.outgoingLane = outgoingLane;
@@ -85,10 +87,10 @@ public class TrafficLight implements Serializable {
     }
 
     /**
-     * Return the signal id (index) within the traffic light group.
+     * Return the index within the traffic light group.
      */
-    public int getId() {
-        return id;
+    public int getIndex() {
+        return index;
     }
 
     public GeoPoint getPosition() {
@@ -108,7 +110,7 @@ public class TrafficLight implements Serializable {
         return new HashCodeBuilder(5, 79)
                 .append(incomingLane)
                 .append(outgoingLane)
-                .append(id)
+                .append(index)
                 .append(position)
                 .append(currentState)
                 .toHashCode();
@@ -130,7 +132,7 @@ public class TrafficLight implements Serializable {
         return new EqualsBuilder()
                 .append(this.incomingLane, other.incomingLane)
                 .append(this.outgoingLane, other.outgoingLane)
-                .append(this.id, other.id)
+                .append(this.index, other.index)
                 .append(this.position, other.position)
                 .append(this.currentState, other.currentState)
                 .isEquals();
@@ -139,7 +141,7 @@ public class TrafficLight implements Serializable {
     @Override
     public String toString() {
         return "TrafficLightSignal{"
-                + "id=" + id
+                + "id=" + index
                 + ", currentState=" + currentState
                 + ", incomingLane=" + incomingLane
                 + ", outgoingLane=" + outgoingLane

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLightGroup.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLightGroup.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +41,7 @@ import javax.annotation.Nonnull;
  */
 public class TrafficLightGroup implements Serializable, ToDataOutput {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**
@@ -78,7 +80,6 @@ public class TrafficLightGroup implements Serializable, ToDataOutput {
      * @throws InternalFederateException if it wasn't possible to construct the object from given data input
      */
     public TrafficLightGroup(DataInput dataInput) throws InternalFederateException {
-        TrafficLightGroup trafficLightGroup;
         try {
             String trafficLightGroupId = dataInput.readUTF();
 
@@ -187,7 +188,7 @@ public class TrafficLightGroup implements Serializable, ToDataOutput {
         for (TrafficLight signal : trafficLightList) {
 
             //write traffic light (signal) id
-            dataOutput.writeInt(signal.getId());
+            dataOutput.writeInt(signal.getIndex());
 
             //write geo position
             SerializationUtils.encodeGeoPoint(dataOutput, signal.getPosition());
@@ -203,7 +204,7 @@ public class TrafficLightGroup implements Serializable, ToDataOutput {
         }
 
         //write the amount of traffic light programs available for this group
-        dataOutput.writeInt(programs.values().size());
+        dataOutput.writeInt(programs.size());
 
         for (TrafficLightProgram trafficLightProgram : programs.values()) {
 

--- a/lib/mosaic-objects/src/test/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLightTest.java
+++ b/lib/mosaic-objects/src/test/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLightTest.java
@@ -38,7 +38,7 @@ public class TrafficLightTest{
 
     @Test
     public void getId() {
-        assertEquals("Traffic light id didn't match the expected one", 0, trafficLight.getId());
+        assertEquals("Traffic light id didn't match the expected one", 0, trafficLight.getIndex());
     }
 
     @Test

--- a/lib/mosaic-objects/src/test/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLightTest.java
+++ b/lib/mosaic-objects/src/test/java/org/eclipse/mosaic/lib/objects/trafficlight/TrafficLightTest.java
@@ -37,7 +37,7 @@ public class TrafficLightTest{
     }
 
     @Test
-    public void getId() {
+    public void getIndex() {
         assertEquals("Traffic light id didn't match the expected one", 0, trafficLight.getIndex());
     }
 


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* this PR renames the `id` field in the `TrafficLight` class (which essentially is more of a signal for 1 incoming and 1 outgoing lane) to `index`.
* This change is a sensible change as the `id` really is just an index and not an id, i.e., it's not a unique identifier.
* In general MOSAICs traffic light implementation leads too strongly on SUMOs implementation (i.e., a group of signals makes up a traffic light). In the future we could research how other simulators handle traffic lights and find a good common ground.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves issue internal issue 1028
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

As far as I can see, no.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

