### PR TITLE
fix(rti): tee output streams before passing them to connectToFederate, copy Dockerfiles to mosaic-starter

### DIFF
--- a/bundle/src/assembly/resources/fed/ns3/Dockerfile
+++ b/bundle/src/assembly/resources/fed/ns3/Dockerfile
@@ -30,7 +30,7 @@ COPY ./ns* ./
 
 RUN ./ns3_installer.sh --yes 
 RUN mkdir -p ns3config
-RUN chmod -R 755 run.sh ns-allinone-3* && chmod -R 777 ns3config
+RUN chmod -R 755 run.sh ns* && chmod -R 777 ns3config
 
 VOLUME ["/home/mosaic/bin/fed/ns3/ns3config"]
 

--- a/bundle/src/assembly/resources/fed/omnetpp/Dockerfile
+++ b/bundle/src/assembly/resources/fed/omnetpp/Dockerfile
@@ -25,7 +25,7 @@ COPY ./*.tgz omnet_installer.sh ./
 
 RUN \
     ls -all && \
-    ./omnet_installer.sh -q -t USER -o "/home/mosaic/bin/fed/omnetpp/omnetpp-5.5.1-src-linux.tgz" -i "/home/mosaic/bin/fed/omnetpp/inet-4.1.1-src.tgz" && \
+    ./omnet_installer.sh -q -t USER && \
     mkdir -p omnetpp-federate/simulations && \
     chmod -R 755 inet omnetpp-5.5.1 && \
     chmod -R 777 omnetpp-federate

--- a/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
+++ b/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
@@ -184,13 +184,13 @@ public abstract class AbstractNetworkAmbassador extends AbstractFederateAmbassad
 
             while ((matchedOutPort = outputScanner.findInLine(outPortPattern)) == null
                     && (matchedError = outputScanner.findInLine(errorPattern)) == null) {
-                log.trace(outputScanner.nextLine());
+                log.debug("Federate stdout: " + outputScanner.nextLine());
             }
 
             // do not close outputScanner, as it would close the underlying stream.
 
             if (matchedOutPort != null) {
-                log.trace("Found string \"{}\" in stdout", matchedOutPort);
+                log.debug("Found string \"{}\" in stdout", matchedOutPort);
                 int port = Integer.parseInt(matchedOutPort.split("=")[1]);
                 port = getHostPortFromDockerPort(port);
                 connectToFederate(host, port);

--- a/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
+++ b/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
@@ -184,7 +184,7 @@ public abstract class AbstractNetworkAmbassador extends AbstractFederateAmbassad
 
             while ((matchedOutPort = outputScanner.findInLine(outPortPattern)) == null
                     && (matchedError = outputScanner.findInLine(errorPattern)) == null) {
-                log.debug("Federate stdout: " + outputScanner.nextLine());
+                outputScanner.nextLine();
             }
 
             // do not close outputScanner, as it would close the underlying stream.

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
@@ -15,20 +15,37 @@
 
 package org.eclipse.mosaic.lib.util;
 
+import com.google.common.base.Charsets;
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 
+/**
+ * A thread which reads lines from a provided {@link InputStream} (e.g., stdout of a process), and
+ * feeds them into a {@link Consumer} to print or log the read lines.
+ */
 public class ProcessLoggingThread extends Thread {
 
     private final String processName;
     private final Consumer<String> lineConsumer;
     private final InputStream stream;
-    private boolean running = true;
+    private boolean started = false;
+    private boolean closed = false;
+
+    private final List<TeeInputStream> tees = new ArrayList<>();
 
     public ProcessLoggingThread(String processName, InputStream stream, Consumer<String> lineConsumer) {
         this.processName = processName;
@@ -36,12 +53,35 @@ public class ProcessLoggingThread extends Thread {
         this.lineConsumer = lineConsumer;
     }
 
+    /**
+     * An {@link InputStream} cannot be read twice. Reading it simultaneously results in unexpected results and blocking.
+     * Therefore, this method creates a copy of the initially provided {@link InputStream} which can be read simultaneously
+     * by another thread by using a buffer which is filled by reading the initially provided stream.
+     *
+     * <br><br>Note: If the returned {@link InputStream} is not processed/read constantly, lines produced by the initial
+     * input stream might be lost, since only a limited number of lines are buffered.
+     *
+     * @return an {@link InputStream} returning the output produced by the initially provided InputStream
+     */
+    public InputStream teeInputStream() {
+        if (started) {
+            throw new IllegalStateException("Tee must be created before starting process logging thread.");
+        }
+        final TeeInputStream teeInputStream = new TeeInputStream(this);
+        tees.add(teeInputStream);
+        return teeInputStream;
+    }
+
     public void close() {
-        running = false;
+        closed = true;
     }
 
     @Override
     public void run() {
+        if (closed) {
+            throw new IllegalStateException("ProcessLoggingThread cannot be started twice.");
+        }
+        started = true;
         flushLog(this.stream);
     }
 
@@ -53,11 +93,17 @@ public class ProcessLoggingThread extends Thread {
     @SuppressWarnings(value = "REC_CATCH_EXCEPTION",
             justification = "Read exception will always occur if something goes wrong and the process we monitor is dead.")
     private void flushLog(InputStream stream) {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))){
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
 
             String line;
-            while (running) {
+            while (!closed) {
                 if ((line = reader.readLine()) != null) {
+                    for (TeeInputStream teeInputStream : tees) {
+                        // if the queue is full, we don't add anymore lines, to avoid blocking.
+                        if (teeInputStream.lineQueue.remainingCapacity() > 0) {
+                            teeInputStream.lineQueue.add(line);
+                        }
+                    }
                     lineConsumer.accept("Process " + processName + ": " + line);
                 }
             }
@@ -66,6 +112,39 @@ public class ProcessLoggingThread extends Thread {
             /* Read exception will always occur, if something goes wrong and the process we monitor is dead.
              * Therefore it is a normal behavior and it is safe to ignore them.
              */
+        }
+    }
+
+    /**
+     * Anything the parent {@link ProcessLoggingThread} reads from the initially provided
+     * {@link InputStream} is written in a queue. This class provides the possibility
+     * to read and empty that queue by extending a {@link PipedInputStream}, thus providing
+     * a tee input stream (basically, a copy of the initially provided {@link InputStream}).
+     * A thread is used to wait until new lines are added to the queue to make them available
+     * for consumers of this {@link InputStream}.
+     */
+    private static class TeeInputStream extends PipedInputStream {
+
+        private final static int LINE_BUFFER_SIZE = 1000;
+
+        private final BlockingQueue<String> lineQueue = new LinkedBlockingQueue<>(LINE_BUFFER_SIZE);
+
+        private TeeInputStream(ProcessLoggingThread parent) {
+            new Thread(() -> {
+                try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new PipedOutputStream(this), Charsets.UTF_8))) {
+                    while (!parent.closed) {
+                        writer.write(lineQueue.take());
+                        writer.newLine();
+                        writer.flush();
+                    }
+                    writer.write(-1); // EOF
+                    writer.flush();
+                } catch (IOException | InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    parent.tees.remove(this);
+                }
+            }).start();
         }
     }
 }

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
@@ -79,7 +79,10 @@ public class ProcessLoggingThread extends Thread {
     @Override
     public void run() {
         if (closed) {
-            throw new IllegalStateException("ProcessLoggingThread cannot be started twice.");
+            throw new IllegalStateException("ProcessLoggingThread cannot be run another time.");
+        }
+        if (started) {
+            throw new IllegalStateException("ProcessLoggingThread is already running.");
         }
         started = true;
         flushLog(this.stream);

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
@@ -271,8 +271,8 @@ public class LocalFederationManagement implements FederationManagement {
         // possible output from the federates' output stream (e.g. port number...)
         // note: error- and input streams were read in this class now due to conflicting stream access
         handle.getAmbassador().connectToFederate(LOCALHOST,
-                new CloseShieldInputStream(p.getInputStream()), // prevent streams from closing by ambassador
-                new CloseShieldInputStream(p.getErrorStream())
+                CloseShieldInputStream.wrap(p.getInputStream()), // prevent streams from closing by ambassador
+                CloseShieldInputStream.wrap(p.getErrorStream())
         );
 
         // read the federates stdout in an extra thread and add this to our logging instance

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
@@ -27,13 +27,13 @@ import org.eclipse.mosaic.rti.api.parameters.FederateDescriptor;
 import ch.qos.logback.classic.LoggerContext;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -44,6 +44,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * This implementation of <code>FederationManagement</code> allows local
@@ -254,33 +255,31 @@ public class LocalFederationManagement implements FederationManagement {
             watchDog.attachProcess(p);
         }
 
-        // determine the federate's name by its class
-        String federateName = StringUtils.capitalize(handle.getId());
-
-        // read error output of process in an extra thread
-        ProcessLoggingThread errorLoggingThread = new ProcessLoggingThread(
-                federateName, p.getErrorStream(), LoggerFactory.getLogger(federateName + "Error")::error
-        );
-        errorLoggingThread.start();
-        loggingThreads.put(handle.getId(), errorLoggingThread);
-
-        // FIXME: Omnetpp/Ns3 ambassadors must read from the input stream. As we cannot simply split the stream,
-        //        we need to call connectToFederate before starting the ProcessLoggingThread
-        //
-        // call connectToFederateMethod of the current federate an extract
-        // possible output from the federates' output stream (e.g. port number...)
-        // note: error- and input streams were read in this class now due to conflicting stream access
-        handle.getAmbassador().connectToFederate(LOCALHOST,
-                CloseShieldInputStream.wrap(p.getInputStream()), // prevent streams from closing by ambassador
-                CloseShieldInputStream.wrap(p.getErrorStream())
-        );
+        final String federateName = StringUtils.capitalize(handle.getId());
 
         // read the federates stdout in an extra thread and add this to our logging instance
-        ProcessLoggingThread outputLoggingThread = new ProcessLoggingThread(
-                federateName, p.getInputStream(), LoggerFactory.getLogger(federateName + "Output")::info
+        final InputStream teedStdOut = createProcessLogging(
+                handle.getId(), p.getInputStream(), LoggerFactory.getLogger(federateName + "Output")::info
         );
-        outputLoggingThread.start();
-        loggingThreads.put(handle.getId(), outputLoggingThread);
+
+        // read error output of process in an extra thread
+        final InputStream teedErrOut = createProcessLogging(
+                handle.getId(), p.getErrorStream(), LoggerFactory.getLogger(federateName + "Error")::error
+        );
+
+        // call connectToFederateMethod of the current federate an extract
+        // possible output from the federates' output stream (e.g. port number...)
+        handle.getAmbassador().connectToFederate(LOCALHOST, teedStdOut, teedErrOut);
+    }
+
+    private InputStream createProcessLogging(String federateId, InputStream processStream, Consumer<String> lineConsumer) {
+        final ProcessLoggingThread loggingThread = new ProcessLoggingThread(
+                StringUtils.capitalize(federateId), processStream, lineConsumer
+        );
+        final InputStream teedProcessStream = loggingThread.teeInputStream();
+        loggingThread.start();
+        loggingThreads.put(federateId, loggingThread);
+        return teedProcessStream;
     }
 
     /**

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
@@ -98,6 +98,9 @@ public class LocalFederationManagement implements FederationManagement {
     @Override
     public void addFederate(FederateDescriptor descriptor) throws Exception {
         this.log.info("Add ambassador/federate with id '{}'", descriptor.getId());
+
+        this.federateDescriptors.put(descriptor.getId(), descriptor);
+
         if (descriptor.isToDeployAndUndeploy()) {
             this.deployFederate(descriptor);
         }
@@ -107,7 +110,6 @@ public class LocalFederationManagement implements FederationManagement {
         }
 
         descriptor.getAmbassador().setRtiAmbassador(federation.createRtiAmbassador(descriptor.getId()));
-        this.federateDescriptors.put(descriptor.getId(), descriptor);
         this.federateAmbassadors.put(descriptor.getId(), descriptor.getAmbassador());
     }
 

--- a/rti/mosaic-starter/pom.xml
+++ b/rti/mosaic-starter/pom.xml
@@ -178,6 +178,23 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <!-- copy bundle/.../bin/fed to bin/fed -->
+                    <execution>
+                        <id>copy-resources-bin-fed</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/bin/fed</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/bundle/src/assembly/resources/fed</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

This MR solves four issues:

1) Resolves a very old bug/misbehavior which resulted in hiccups when starting OMNeT++ or ns-3 federate. The ambassador would read the provided stdout and errout from the started process to search for the output port and error statements, inside `connectToFederate`. However, simultaneously the ProcessLoggingThread is used to pipe all stdout and errout from the process to the `CommunicationDetails.log` file. The problem here is, that the stream is read twice. To prevent this, we already started the ProcessLoggingThread for the stdout _after_ the call of `connectToFederate`. For the errout, we still started the ProcessLoggingStread before `connectToFederate`, as otherwise, spotting errors in the federate output would be impossible. However, inside `connectToFedarate`, the errout is also processed to search for a potential error message. This leads to occasional blocking dead-locks since the stream is consumed from two threads.\
\
Now, the solution is, to split/copy/tee the original stdout/errout stream so it can be read simultaneously. This is done, by writing everything what the ProcessLoggingThread is reading into a buffer queue. For the call of `connectToFederate` we now pass a copy of the provided stream which reads from that buffer queue. That way, we can collect every output from the federate to `CommuncationDetails.log`, while still being able to parse the stdout/errout inside the ambassador. We use the term "tee" for that, coming from the unix command `tee`.

2) Starting a federate docker container was by running the container in detach mode, and attach later to it to catch stdout of the federate. It's advised to not use `docker attach` for that, since the output between both calls `run` and `attach` can be get lost. This is now fixed by using `docker logs -f` to follow all recent and follow output of the docker container.

3) When a docker federate could not be started properly, the whole federation is killed after watchdog timeout. It also tries to cleanup and stop all started federates. However, if a federate could not be started completely and the watchdog interrupts, it was not cleaned since it was not registered as a running federate. This is now changed by registering any federate before attempting to start it. 

4) The Dockerfiles for the ns-3 federate and the omnet++-federate are copied to `mosaic-starter/bin/fed` to be able to use them directly by CI. Furthermore, a minor fix in Dockerfile for ns3-federate was required for correct permissions.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 1088
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer
