### PR TITLE
fix(utils): use FieldNameStrategy instead of @SerializedName

### DIFF
--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/MutableGeoPoint.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/MutableGeoPoint.java
@@ -35,19 +35,16 @@ public class MutableGeoPoint implements GeoPoint {
     /**
      * The latitude coordinate of this {@link MutableGeoPoint}. Unit: [degree (angle)].
      */
-    @SerializedName(value = "latitude", alternate = {"lat"})
     public double latitude;
 
     /**
      * The longitude coordinate of this {@link MutableGeoPoint}.Unit: [degree (angle)].
      */
-    @SerializedName(value = "longitude", alternate = {"lon"})
     public double longitude;
 
     /**
      * The altitude coordinate of this {@link MutableGeoPoint}. Unit: meter.
      */
-    @SerializedName(value = "altitude", alternate = {"alt"})
     public double altitude;
 
     /**

--- a/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
+++ b/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
@@ -185,7 +185,8 @@ public abstract class AbstractNetworkAmbassador extends AbstractFederateAmbassad
         this.removedNodes = new ArrayList<>();
 
         try {
-            config = new ObjectInstantiation<>(CAbstractNetworkAmbassador.class, log).readFile(ambassadorParameter.configuration);
+            config = new ObjectInstantiation<>(CAbstractNetworkAmbassador.class, log)
+                    .readFile(ambassadorParameter.configuration, CAbstractNetworkAmbassador.createConfigBuilder());
         } catch (InstantiationException | NullPointerException e) {
             log.warn("Problem when instantiating ambassador configuration from '{}'. Ignore file and try again with default config.", ambassadorParameter.configuration);
             config = new CAbstractNetworkAmbassador();

--- a/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/CAbstractNetworkAmbassador.java
+++ b/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/CAbstractNetworkAmbassador.java
@@ -18,15 +18,19 @@ package org.eclipse.mosaic.lib.coupling;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 
+import com.google.gson.GsonBuilder;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public final class CAbstractNetworkAmbassador {
 
+    /**
+     * Name to the federate configuration file.
+     */
     public String federateConfigurationFile;
-
-    public String regionConfigurationFile;
 
     /**
      * List of base stations and their properties.
@@ -46,6 +50,7 @@ public final class CAbstractNetworkAmbassador {
      * Configuration structure of one single base station.
      */
     public static class CBaseStationProperties implements Serializable {
+
         /**
          * The base stations geo position.
          */
@@ -63,6 +68,16 @@ public final class CAbstractNetworkAmbassador {
             s += " cartesianPosition: " + ((cartesianPosition != null) ? cartesianPosition.toString() : "null");
             return s;
         }
+    }
+
+    static GsonBuilder createConfigBuilder() {
+        return new GsonBuilder()
+                .setFieldNamingStrategy(f -> switch (f.getName()) {
+                    case "latitude" -> "lat";
+                    case "longitude" -> "lon";
+                    case "altitude" -> "alt";
+                    default -> f.getName();
+                });
     }
 
 

--- a/lib/mosaic-network/src/main/resources/CAbstractNetworkAmbassadorScheme.json
+++ b/lib/mosaic-network/src/main/resources/CAbstractNetworkAmbassadorScheme.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "AbstractNetworkAmbassador",
+    "description": "Schema describing the JSON file structure for the network simulator configuration.",
+    "type": "object",
+    "properties": {
+        "federateConfigurationFile": {
+            "type": "string",
+            "description": "Name to the federate configuration file."
+        },
+        "baseStations": {
+            "type": "array",
+            "description": "List of base stations and their properties.",
+            "items": {
+                "type": "object",
+                "title": "BaseStationProperties",
+                "properties": {
+                    "geoPosition": {
+                        "type": "object",
+                        "description": "Geographic position of the base station.",
+                        "properties": {
+                            "lat": {
+                                "type": "number",
+                                "description": "Latitude in decimal degrees."
+                            },
+                            "lon": {
+                                "type": "number",
+                                "description": "Longitude in decimal degrees."
+                            },
+                            "alt": {
+                                "type": "number",
+                                "description": "Altitude in meters.",
+                                "nullable": true
+                            }
+                        },
+                        "required": [ "lat", "lon" ]
+                    },
+                    "cartesianPosition": {
+                        "type": "object",
+                        "description": "Cartesian coordinates of the base station (used if geoPosition is not provided).",
+                        "properties": {
+                            "x": {
+                                "type": "number",
+                                "description": "X coordinate."
+                            },
+                            "y": {
+                                "type": "number",
+                                "description": "Y coordinate."
+                            },
+                            "z": {
+                                "type": "number",
+                                "description": "Z coordinate.",
+                                "nullable": true
+                            }
+                        },
+                        "required": [ "x", "y" ]
+                    }
+                },
+                "anyOf": [
+                    { "required": [ "geoPosition" ] },
+                    { "required": [ "cartesianPosition" ] }
+                ]
+            }
+        }
+    }
+}

--- a/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassadorTest.java
+++ b/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassadorTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.mosaic.lib.coupling;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -29,12 +28,11 @@ import static org.mockito.Mockito.when;
 import org.eclipse.mosaic.interactions.communication.AdHocCommunicationConfiguration;
 import org.eclipse.mosaic.interactions.mapping.RsuRegistration;
 import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
-import org.eclipse.mosaic.lib.coupling.ClientServerChannelProtos.CommandMessage.CommandType;
 import org.eclipse.mosaic.lib.coupling.ClientServerChannelProtos.AddNode.NodeType;
+import org.eclipse.mosaic.lib.coupling.ClientServerChannelProtos.CommandMessage.CommandType;
 import org.eclipse.mosaic.lib.enums.AdHocChannel;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
-import org.eclipse.mosaic.lib.geo.MutableCartesianPoint;
 import org.eclipse.mosaic.lib.geo.UtmPoint;
 import org.eclipse.mosaic.lib.geo.UtmZone;
 import org.eclipse.mosaic.lib.junit.GeoProjectionRule;
@@ -52,8 +50,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -62,8 +58,6 @@ import java.net.UnknownHostException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractNetworkAmbassadorTest {
-
-    private final static Logger log = LoggerFactory.getLogger(AbstractNetworkAmbassadorTest.class);
 
     @Mock
     public ClientServerChannel ambassadorFederateChannelMock;

--- a/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/CAbstractNetworkAmbassadorTest.java
+++ b/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/CAbstractNetworkAmbassadorTest.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.mosaic.lib.coupling;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.mosaic.lib.util.objects.ObjectInstantiation;
 
 import org.junit.Test;
@@ -23,13 +25,28 @@ public class CAbstractNetworkAmbassadorTest {
 
     @Test
     public void tiergartenOmnetpp() throws InstantiationException {
-        new ObjectInstantiation<>(CAbstractNetworkAmbassador.class)
-                .read(getClass().getResourceAsStream("/Tiergarten/omnetpp_config.json"));
+        new ObjectInstantiation<>(CAbstractNetworkAmbassador.class).read(
+                getClass().getResourceAsStream("/Tiergarten/omnetpp_config.json"), CAbstractNetworkAmbassador.createConfigBuilder()
+        );
     }
 
     @Test
     public void tiergartenNs3() throws InstantiationException {
-        new ObjectInstantiation<>(CAbstractNetworkAmbassador.class)
-                .read(getClass().getResourceAsStream("/Tiergarten/ns3_config.json"));
+        new ObjectInstantiation<>(CAbstractNetworkAmbassador.class).read(
+                getClass().getResourceAsStream("/Tiergarten/ns3_config.json"), CAbstractNetworkAmbassador.createConfigBuilder()
+        );
+    }
+
+    @Test
+    public void withBaseStations() throws InstantiationException {
+        CAbstractNetworkAmbassador config = new ObjectInstantiation<>(CAbstractNetworkAmbassador.class).read(
+                getClass().getResourceAsStream("/ns3_config_with_basestations.json"), CAbstractNetworkAmbassador.createConfigBuilder()
+        );
+        assertEquals(2, config.baseStations.size());
+        assertEquals(52.5131, config.baseStations.get(0).geoPosition.getLatitude(), 0.0001d);
+        assertEquals(13.3249, config.baseStations.get(0).geoPosition.getLongitude(), 0.0001d);
+
+        assertEquals(719.3, config.baseStations.get(1).cartesianPosition.getX(), 0.1d);
+        assertEquals(118.2, config.baseStations.get(1).cartesianPosition.getY(), 0.1d);
     }
 }

--- a/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/NetworkEntityIdTransformerTest.java
+++ b/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/NetworkEntityIdTransformerTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class NetworkEntityIdTransformerTest {
 
     private NetworkEntityIdTransformer idTransformer;

--- a/lib/mosaic-network/src/test/resources/ns3_config_with_basestations.json
+++ b/lib/mosaic-network/src/test/resources/ns3_config_with_basestations.json
@@ -1,0 +1,13 @@
+{
+    "baseStations": [
+        {
+            "id": "tuberlin1",
+            "geoPosition": { "lon": 13.3249, "lat": 52.5131 },
+            "cartesianPosition": {"x": 558, "y": 188, "z": 12345}
+        },
+        {
+            "id": "tuberlin2",
+            "cartesianPosition": {"x": 719.314, "y": 118.181, "z": 0}
+        }
+    ]
+}


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* Don't use @SerializedName as alternative names are ignored during serialization. With this PR, we switch back so that `FieldNameStrategy` in mosaic-cell can be used instead.
* Added a JSON scheme file for validating `ns3_config.json` and `omnetpp_config.json` configuration files.
* Use custom FieldNameStrategy for CAbstractNetworkAmbassador to shortcut from `latitude` to `lat` and so on.
* Added test to check validation of network-config with base stations.

**To be discussed**
* [x] Is it necessary to have short `lat` and `lon`, or could we stick to the long words as everywhere else. -> switch to long words everywhere (also in cell) in follow up issue
* [x] Do we want to include/use the `id` field to the basestation for logging? --> no

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* No issues, fixes main :)
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

