### PR TITLE
fix: Use one single CodedInputStream and reduce memory consumption

### DIFF
--- a/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/ClientServerChannel.java
+++ b/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/ClientServerChannel.java
@@ -94,7 +94,7 @@ public class ClientServerChannel {
         // Buffer the socket stream to reduce tiny reads and allocations
         BufferedInputStream bin = new BufferedInputStream(socket.getInputStream(), 64 * 1024);
         this.cin = CodedInputStream.newInstance(bin);
-        this.cin.setSizeLimit(4 * 1024 * 1024); // guardrail: 4MB per message, adjust as needed
+        this.cin.setSizeLimit(1 * 1024 * 1024); // guardrail: 1MB per message, adjust as needed
         this.out = new DataOutputStream(socket.getOutputStream());
         // TODO: use logger
     }
@@ -120,6 +120,7 @@ public class ClientServerChannel {
             return parser.parseFrom(cin);
         } finally {
             cin.popLimit(oldLimit);
+            cin.resetSizeCounter(); // avoids cumulative sizeLimit hits
         }
     }
 

--- a/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/ClientServerChannel.java
+++ b/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/ClientServerChannel.java
@@ -43,10 +43,10 @@ import org.eclipse.mosaic.lib.objects.communication.InterfaceConfiguration;
 import org.eclipse.mosaic.lib.objects.v2x.V2xReceiverInformation;
 import org.eclipse.mosaic.lib.util.objects.IdTransformer;
 
-import org.apache.commons.lang3.Validate;
+import com.google.protobuf.CodedInputStream;
 import org.slf4j.Logger;
 
-import java.io.DataInputStream;
+import java.io.BufferedInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -73,7 +73,7 @@ public class ClientServerChannel {
     /**
      * Input stream from network federate.
      */
-    final private InputStream in;
+    private final CodedInputStream cin;
 
     /**
      * Output stream to network federate.
@@ -91,7 +91,10 @@ public class ClientServerChannel {
     public ClientServerChannel(InetAddress host, int port, Logger log) throws IOException {
         this.socket = new Socket(host, port);
         socket.setTcpNoDelay(true);
-        this.in = new DataInputStream(socket.getInputStream());
+        // Buffer the socket stream to reduce tiny reads and allocations
+        BufferedInputStream bin = new BufferedInputStream(socket.getInputStream(), 64 * 1024);
+        this.cin = CodedInputStream.newInstance(bin);
+        this.cin.setSizeLimit(4 * 1024 * 1024); // guardrail: 4MB per message, adjust as needed
         this.out = new DataOutputStream(socket.getOutputStream());
         // TODO: use logger
     }
@@ -107,6 +110,19 @@ public class ClientServerChannel {
     //                  Reading methods
     //####################################################################
 
+    /*
+     * Helper function to only use one single CodedInputStream (instead of building a CodedInputStream for every new read*Message call)
+     */
+    private <T> T parseDelimited(com.google.protobuf.Parser<T> parser) throws IOException {
+        int size = cin.readRawVarint32();
+        int oldLimit = cin.pushLimit(size);
+        try {
+            return parser.parseFrom(cin);
+        } finally {
+            cin.popLimit(oldLimit);
+        }
+    }
+
     /**
      * Reads a wifi message from the incoming channel.
      * TODO: ChannelID (and length) not yet treated
@@ -114,12 +130,12 @@ public class ClientServerChannel {
      * @return The read message.
      */
     public ReceiveWifiMessageRecord readReceiveWifiMessage(IdTransformer<Integer, String> idTransformer) throws IOException {
-        ReceiveWifiMessage receiveMessage = Validate.notNull(ReceiveWifiMessage.parseDelimitedFrom(in), "Could not read message body.");
-        V2xReceiverInformation recInfo = new V2xReceiverInformation(receiveMessage.getTime()).signalStrength(receiveMessage.getRssi());
+        ReceiveWifiMessage m = parseDelimited(ReceiveWifiMessage.parser());
+        V2xReceiverInformation recInfo = new V2xReceiverInformation(m.getTime()).signalStrength(m.getRssi());
         return new ReceiveWifiMessageRecord(
-                receiveMessage.getTime(),
-                idTransformer.fromExternalId(receiveMessage.getNodeId()),
-                receiveMessage.getMessageId(),
+                m.getTime(),
+                idTransformer.fromExternalId(m.getNodeId()),
+                m.getMessageId(),
                 recInfo
         );
     }
@@ -131,11 +147,11 @@ public class ClientServerChannel {
      * @return The read message.
      */
     public ReceiveCellMessageRecord readReceiveCellMessage(IdTransformer<Integer, String> idTransformer) throws IOException {
-        ReceiveCellMessage msg = Validate.notNull(ReceiveCellMessage.parseDelimitedFrom(in), "Could not read message body.");
+        ReceiveCellMessage m = parseDelimited(ReceiveCellMessage.parser());
         return new ReceiveCellMessageRecord(
-                msg.getTime(),
-                idTransformer.fromExternalId(msg.getNodeId()),
-                msg.getMessageId()
+                m.getTime(),
+                idTransformer.fromExternalId(m.getNodeId()),
+                m.getMessageId()
         );
     }
 
@@ -145,8 +161,8 @@ public class ClientServerChannel {
      * @return the read port as int
      */
     public int readPortBody() throws IOException {
-        PortExchange portExchange = Validate.notNull(PortExchange.parseDelimitedFrom(in), "Could not read port.");
-        return portExchange.getPortNumber();
+        PortExchange m = parseDelimited(PortExchange.parser());
+        return m.getPortNumber();
     }
 
     /**
@@ -155,8 +171,8 @@ public class ClientServerChannel {
      * @return the read time as long
      */
     public long readTimeBody() throws IOException {
-        TimeMessage timeMessage = Validate.notNull(TimeMessage.parseDelimitedFrom(in), "Could not read time.");
-        return timeMessage.getTime();
+        TimeMessage m = parseDelimited(TimeMessage.parser());
+        return m.getTime();
     }
 
     /**
@@ -165,8 +181,8 @@ public class ClientServerChannel {
      * @return the read command
      */
     public CommandType readCommand() throws IOException {
-        CommandMessage commandMessage = Validate.notNull(CommandMessage.parseDelimitedFrom(in), "Could not read command.");
-        return commandMessage.getCommandType();
+        CommandMessage m = parseDelimited(CommandMessage.parser());
+        return m.getCommandType();
     }
 
     //####################################################################


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

The memory consumption was very high when reading messages from the protobuf (client server channel).
This refactoring now uses a BufferedInputStream (less reads on OS level) and only one instance of CodedInputStream, instead of building a CodedInputStream for every new message read.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 1109
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required? No.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

